### PR TITLE
feat: detect foreign keys and emit cr:references between RecordSets

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,6 +12,7 @@ programmatically — without the CLI.
         - generate_metadata
         - save_metadata
         - scan_report
+        - reference_report
 
 ## Scan coverage
 
@@ -34,6 +35,22 @@ still explain itself.
 ::: croissant_baker.entries.Outcome
 
 ::: croissant_baker.entries.Reason
+
+## Foreign-key detection
+
+Opt-in, via `--detect-references` or `detect_references=True`. The report is
+`None` when the pass did not run, so "found nothing" and "never asked" stay
+distinguishable. Shared key columns it declines to link are carried here rather
+than dropped.
+
+::: croissant_baker.references.ReferenceReport
+    options:
+      members:
+        - links
+        - unresolved
+        - summary_lines
+
+::: croissant_baker.references.Unlinkable
 
 ## File Discovery
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,6 +40,7 @@ $ croissant-baker [OPTIONS] COMMAND [ARGS]...
 * `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Matches by bare column name across all RecordSets; a warning prints if a name resolves to multiple fields. Repeatable; combine with --field-mappings (flags override YAML).
 * `--count-csv-rows`: Count exact row numbers for CSV files (slow for large datasets)
 * `-j, --jobs INTEGER`: Worker threads for file extraction. 0 = auto (from CPU count), 1 = serial. Output is identical regardless of this value.  [default: 0]
+* `--detect-references`: Detect foreign keys between tables that share a key column (e.g. subject_id) and emit cr:references links. Conservative: links only when a parent table is identifiable by name; shared keys it will not link are reported, and named under --verbose.
 * `--rai-data-collection TEXT`: How and where the data was gathered.
 * `--rai-data-collection-type TEXT`: Collection type, e.g. 'observational'. Can be used multiple times.
 * `--rai-data-collection-missing-data TEXT`: How missing data was handled during collection.

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -501,6 +501,11 @@ def main(
         "-j",
         help="Worker threads for file extraction. 0 = auto (from CPU count), 1 = serial. Output is identical regardless of this value.",
     ),
+    detect_references: bool = typer.Option(
+        False,
+        "--detect-references",
+        help="Detect foreign keys between tables that share a key column (e.g. subject_id) and emit cr:references links. Conservative: links only when a parent table is identifiable by name.",
+    ),
     # Native mlcroissant RAI fields exposed directly as CLI flags.
     rai_data_collection: Optional[str] = typer.Option(
         None, "--rai-data-collection", help="How and where the data was gathered."
@@ -794,6 +799,7 @@ def main(
             field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
             max_workers=jobs or None,
+            detect_references=detect_references,
             includes=include,
             excludes=exclude,
             rai_fields=native_rai_fields,

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -178,6 +178,25 @@ def _echo_scan_coverage(
         )
 
 
+def _echo_reference_summary(
+    generator: Optional["MetadataGenerator"], verbose: bool
+) -> None:
+    """Print what foreign-key detection linked, and what it declined to link.
+
+    Silent unless ``--detect-references`` ran: the report is ``None`` otherwise,
+    so a default bake says nothing about a pass it never made. Like the coverage
+    section, the default is one line whatever the dataset, and only ``--verbose``
+    names a column per line.
+    """
+    if generator is None:
+        return
+    report = generator.reference_report
+    if report is None:
+        return
+    for line in report.summary_lines(verbose=verbose):
+        typer.echo(line)
+
+
 def _warn_missing_spec_fields(**provided: object) -> None:
     """Warn about spec-required fields that were not explicitly provided."""
     missing = [
@@ -554,7 +573,7 @@ def main(
     detect_references: bool = typer.Option(
         False,
         "--detect-references",
-        help="Detect foreign keys between tables that share a key column (e.g. subject_id) and emit cr:references links. Conservative: links only when a parent table is identifiable by name.",
+        help="Detect foreign keys between tables that share a key column (e.g. subject_id) and emit cr:references links. Conservative: links only when a parent table is identifiable by name; shared keys it will not link are reported, and named under --verbose.",
     ),
     # Native mlcroissant RAI fields exposed directly as CLI flags.
     rai_data_collection: Optional[str] = typer.Option(
@@ -961,6 +980,7 @@ def main(
         _echo_file_counts(file_count, file_set_count)
         typer.echo(f"Record sets: {record_count}")
         _echo_scan_coverage(generator, report, verbose)
+        _echo_reference_summary(generator, verbose)
         typer.echo(f"Saved to: {output}")
 
         if not validate:

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -551,6 +551,11 @@ def main(
         "-j",
         help="Worker threads for file extraction. 0 = auto (from CPU count), 1 = serial. Output is identical regardless of this value.",
     ),
+    detect_references: bool = typer.Option(
+        False,
+        "--detect-references",
+        help="Detect foreign keys between tables that share a key column (e.g. subject_id) and emit cr:references links. Conservative: links only when a parent table is identifiable by name.",
+    ),
     # Native mlcroissant RAI fields exposed directly as CLI flags.
     rai_data_collection: Optional[str] = typer.Option(
         None, "--rai-data-collection", help="How and where the data was gathered."
@@ -883,6 +888,7 @@ def main(
             field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
             max_workers=jobs or None,
+            detect_references=detect_references,
             includes=include,
             excludes=exclude,
             rai_fields=native_rai_fields,

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -173,6 +173,7 @@ class MetadataGenerator:
         field_mappings: Optional[Dict[str, Dict[str, object]]] = None,
         count_csv_rows: bool = False,
         max_workers: Optional[int] = None,
+        detect_references: bool = False,
         includes: Optional[List[str]] = None,
         excludes: Optional[List[str]] = None,
         rai_fields: Optional[Dict[str, object]] = None,
@@ -217,6 +218,9 @@ class MetadataGenerator:
             max_workers: Maximum worker threads for per-file metadata
                 extraction. None (default) auto-sizes from the CPU count; 1
                 forces serial. Output is identical regardless of this value.
+            detect_references: If True, run conservative foreign-key detection
+                and emit cr:references links between RecordSets that share a key
+                column with a name-identifiable parent table. Defaults to False.
             includes: Glob patterns to include. Applied before excludes.
             excludes: Glob patterns to exclude. Applied after includes.
             rai_fields: Native mlcroissant RAI metadata fields, passed through
@@ -254,6 +258,7 @@ class MetadataGenerator:
         self.excludes = excludes
         self.rai_fields = rai_fields or {}
         self.max_workers = max_workers
+        self.detect_references = detect_references
         # Generic options forwarded to every handler via **kwargs.
         # Handlers declare what they use; others ignore the rest.
         # To add a new handler-specific flag: add one key here — the call site never changes.
@@ -421,6 +426,9 @@ class MetadataGenerator:
             except Exception as e:
                 logger.warning("%s.build_croissant failed: %s", type(_h).__name__, e)
 
+        if self.detect_references and len(record_sets) >= 2:
+            self._apply_reference_detection(record_sets)
+
         _assert_unique_node_ids(distributions, record_sets)
 
         metadata.distribution = distributions
@@ -487,6 +495,61 @@ class MetadataGenerator:
             return (file_path, handler, meta, None)
         except Exception as e:  # noqa: BLE001 — re-surfaced as a per-file warning
             return (file_path, None, None, e)
+
+    def _apply_reference_detection(self, record_sets: list) -> None:
+        """Detect and attach foreign-key cr:references across RecordSets.
+
+        Opt-in via ``detect_references``. Delegates the (pure) detection to
+        ``references.detect_foreign_keys`` and maps its result back onto the real
+        Field objects. Conservative: a child field's ``references`` is set only
+        when a shared key column has a parent RecordSet identifiable by name;
+        unresolved shared keys are logged, not linked.
+        """
+        from croissant_baker.references import detect_foreign_keys
+
+        descriptors = [
+            {
+                "id": rs.id,
+                "name": rs.name or rs.id,
+                "columns": [f.name for f in (rs.fields or [])],
+            }
+            for rs in record_sets
+        ]
+        links, unresolved = detect_foreign_keys(descriptors)
+
+        rs_by_id = {rs.id: rs for rs in record_sets}
+        applied = 0
+        for link in links:
+            parent_rs = rs_by_id.get(link["parent_rs"])
+            child_rs = rs_by_id.get(link["child_rs"])
+            if parent_rs is None or child_rs is None:
+                continue
+            parent_field = next(
+                (f for f in parent_rs.fields if f.name == link["parent_column"]),
+                None,
+            )
+            child_field = next(
+                (f for f in child_rs.fields if f.name == link["column"]), None
+            )
+            if parent_field is None or child_field is None:
+                continue
+            child_field.references = mlc.Source(field=parent_field.id)
+            applied += 1
+
+        if applied or unresolved:
+            logger.info(
+                "reference detection: linked %d foreign key(s); %d shared key(s) "
+                "had no name-identifiable parent",
+                applied,
+                len(unresolved),
+            )
+        for unresolved_key in unresolved:
+            logger.info(
+                "  shared key '%s' across %d record sets — no parent table named "
+                "after it; not linked",
+                unresolved_key["column"],
+                len(unresolved_key["record_sets"]),
+            )
 
     def _build_description(self, file_metadata: list) -> str:
         if self.description:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -21,6 +21,10 @@ from croissant_baker.identifiers import (
     _disambiguate_record_sets,
     serialize_datetime,
 )
+from croissant_baker.references import (
+    ReferenceReport,
+    detect_foreign_keys,
+)
 
 from croissant_baker import compression
 from croissant_baker.handlers.base_handler import BuildResult
@@ -116,6 +120,19 @@ def _apply_field_mappings(
                 count,
                 name,
             )
+
+
+def _field_named(record_set, column: str):
+    """The Field of ``record_set`` whose name is ``column``.
+
+    Raises rather than returning None: the caller looks these up by names the
+    detector copied out of descriptors built from these very Field objects, so
+    a miss is a broken invariant and not an input a link should be dropped over.
+    """
+    for candidate in record_set.fields or []:
+        if candidate.name == column:
+            return candidate
+    raise KeyError(f"record set {record_set.id!r} has no field named {column!r}")
 
 
 class MetadataGenerator:
@@ -252,6 +269,8 @@ class MetadataGenerator:
         # One entry per file the last generate_metadata() call scanned, each
         # carrying what became of it. Empty until then.
         self._scan_entries: list[ScanEntry] = []
+        # What the foreign-key pass found, or None when it did not run.
+        self._reference_report: Optional[ReferenceReport] = None
 
     @property
     def scan_report(self) -> ScanReport:
@@ -263,6 +282,17 @@ class MetadataGenerator:
         error can still ask why. Empty before the first call.
         """
         return ScanReport(self._scan_entries)
+
+    @property
+    def reference_report(self) -> Optional[ReferenceReport]:
+        """What foreign-key detection found, or None when it did not run.
+
+        Three states, because they mean different things to a reader: None
+        for a bake that never ran the pass (``detect_references`` off, or
+        assembly raised before it), an empty report for one that ran and
+        found nothing, and a populated one otherwise.
+        """
+        return self._reference_report
 
     def generate_metadata(self, progress_callback=None) -> dict:
         """Generate complete Croissant metadata for the dataset.
@@ -286,6 +316,7 @@ class MetadataGenerator:
             exclude_patterns=self.excludes,
         )
         self._scan_entries = entries
+        self._reference_report = None
         total_files = len(entries)
 
         # Each worker touches only its own entry, and entries are read back in
@@ -374,8 +405,6 @@ class MetadataGenerator:
                 dependants[entry.duplicate_of].append(entry)
 
         # TODO: future improvements per handler:
-        #   - references: detect foreign-key columns (e.g. subject_id) and emit
-        #     cr:references links between RecordSets — high-impact for EHR data.
         #   - enumerations: for low-cardinality categorical columns, emit
         #     sc:Enumeration RecordSets.
         by_handler: dict = defaultdict(list)
@@ -470,7 +499,7 @@ class MetadataGenerator:
         # batch is visible at once.
         record_sets = _disambiguate_record_sets(batches)
 
-        if self.detect_references and len(record_sets) >= 2:
+        if self.detect_references:
             self._apply_reference_detection(record_sets)
 
         described_metas = [
@@ -628,11 +657,13 @@ class MetadataGenerator:
         Opt-in via ``detect_references``. Delegates the (pure) detection to
         ``references.detect_foreign_keys`` and maps its result back onto the real
         Field objects. Conservative: a child field's ``references`` is set only
-        when a shared key column has a parent RecordSet identifiable by name;
-        unresolved shared keys are logged, not linked.
-        """
-        from croissant_baker.references import detect_foreign_keys
+        when a shared key column has a parent RecordSet identifiable by name.
 
+        What it found is stored on :attr:`reference_report` rather than logged.
+        Nothing configures logging for this package — ``__init__`` attaches a
+        NullHandler — so a log record here reaches nobody, and the CLI owns
+        terminal output.
+        """
         descriptors = [
             {
                 "id": rs.id,
@@ -642,40 +673,15 @@ class MetadataGenerator:
             for rs in record_sets
         ]
         links, unresolved = detect_foreign_keys(descriptors)
+        self._reference_report = ReferenceReport(links=links, unresolved=unresolved)
 
         rs_by_id = {rs.id: rs for rs in record_sets}
-        applied = 0
         for link in links:
-            parent_rs = rs_by_id.get(link["parent_rs"])
-            child_rs = rs_by_id.get(link["child_rs"])
-            if parent_rs is None or child_rs is None:
-                continue
-            parent_field = next(
-                (f for f in parent_rs.fields if f.name == link["parent_column"]),
-                None,
+            parent_field = _field_named(
+                rs_by_id[link["parent_rs"]], link["parent_column"]
             )
-            child_field = next(
-                (f for f in child_rs.fields if f.name == link["column"]), None
-            )
-            if parent_field is None or child_field is None:
-                continue
+            child_field = _field_named(rs_by_id[link["child_rs"]], link["column"])
             child_field.references = mlc.Source(field=parent_field.id)
-            applied += 1
-
-        if applied or unresolved:
-            logger.info(
-                "reference detection: linked %d foreign key(s); %d shared key(s) "
-                "had no name-identifiable parent",
-                applied,
-                len(unresolved),
-            )
-        for unresolved_key in unresolved:
-            logger.info(
-                "  shared key '%s' across %d record sets — no parent table named "
-                "after it; not linked",
-                unresolved_key["column"],
-                len(unresolved_key["record_sets"]),
-            )
 
     def _build_description(self, file_metadata: list) -> str:
         if self.description:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -152,6 +152,7 @@ class MetadataGenerator:
         field_mappings: Optional[Dict[str, Dict[str, object]]] = None,
         count_csv_rows: bool = False,
         max_workers: Optional[int] = None,
+        detect_references: bool = False,
         includes: Optional[List[str]] = None,
         excludes: Optional[List[str]] = None,
         rai_fields: Optional[Dict[str, object]] = None,
@@ -197,6 +198,9 @@ class MetadataGenerator:
             max_workers: Maximum worker threads for per-file metadata
                 extraction. None (default) auto-sizes from the CPU count; 1
                 forces serial. Output is identical regardless of this value.
+            detect_references: If True, run conservative foreign-key detection
+                and emit cr:references links between RecordSets that share a key
+                column with a name-identifiable parent table. Defaults to False.
             includes: Glob patterns to include. Applied before excludes.
             excludes: Glob patterns to exclude. Applied after includes.
             rai_fields: Native mlcroissant RAI metadata fields, passed through
@@ -238,6 +242,7 @@ class MetadataGenerator:
         self.rai_fields = rai_fields or {}
         self.max_workers = max_workers
         self.handlers = handlers if handlers is not None else default_registry()
+        self.detect_references = detect_references
         # Generic options forwarded to every handler via **kwargs.
         # Handlers declare what they use; others ignore the rest.
         # To add a new handler-specific flag: add one key here — the call site never changes.
@@ -465,6 +470,9 @@ class MetadataGenerator:
         # batch is visible at once.
         record_sets = _disambiguate_record_sets(batches)
 
+        if self.detect_references and len(record_sets) >= 2:
+            self._apply_reference_detection(record_sets)
+
         described_metas = [
             (e.handler, e.meta) for e in entries if e.outcome is Outcome.DESCRIBED
         ]
@@ -613,6 +621,61 @@ class MetadataGenerator:
             counter += 1
 
         return objects, counter
+
+    def _apply_reference_detection(self, record_sets: list) -> None:
+        """Detect and attach foreign-key cr:references across RecordSets.
+
+        Opt-in via ``detect_references``. Delegates the (pure) detection to
+        ``references.detect_foreign_keys`` and maps its result back onto the real
+        Field objects. Conservative: a child field's ``references`` is set only
+        when a shared key column has a parent RecordSet identifiable by name;
+        unresolved shared keys are logged, not linked.
+        """
+        from croissant_baker.references import detect_foreign_keys
+
+        descriptors = [
+            {
+                "id": rs.id,
+                "name": rs.name or rs.id,
+                "columns": [f.name for f in (rs.fields or [])],
+            }
+            for rs in record_sets
+        ]
+        links, unresolved = detect_foreign_keys(descriptors)
+
+        rs_by_id = {rs.id: rs for rs in record_sets}
+        applied = 0
+        for link in links:
+            parent_rs = rs_by_id.get(link["parent_rs"])
+            child_rs = rs_by_id.get(link["child_rs"])
+            if parent_rs is None or child_rs is None:
+                continue
+            parent_field = next(
+                (f for f in parent_rs.fields if f.name == link["parent_column"]),
+                None,
+            )
+            child_field = next(
+                (f for f in child_rs.fields if f.name == link["column"]), None
+            )
+            if parent_field is None or child_field is None:
+                continue
+            child_field.references = mlc.Source(field=parent_field.id)
+            applied += 1
+
+        if applied or unresolved:
+            logger.info(
+                "reference detection: linked %d foreign key(s); %d shared key(s) "
+                "had no name-identifiable parent",
+                applied,
+                len(unresolved),
+            )
+        for unresolved_key in unresolved:
+            logger.info(
+                "  shared key '%s' across %d record sets — no parent table named "
+                "after it; not linked",
+                unresolved_key["column"],
+                len(unresolved_key["record_sets"]),
+            )
 
     def _build_description(self, file_metadata: list) -> str:
         if self.description:

--- a/src/croissant_baker/references.py
+++ b/src/croissant_baker/references.py
@@ -1,0 +1,141 @@
+"""Heuristic foreign-key detection across RecordSets (Croissant ``cr:references``).
+
+Croissant can express a foreign key by giving a Field a ``references`` Source that
+points at another RecordSet's field. croissant-baker treats every file as an
+island today (see issue #51 and the inline TODO in ``metadata_generator``); this
+module adds an opt-in pass that links shared key columns across RecordSets.
+
+Design: **conservative, and it never guesses a direction.** A reference is emitted
+only when a shared key column has a parent RecordSet that can be identified *by
+name* — e.g. a ``study_id`` column shared by several tables, with a RecordSet
+named ``studies`` (or ``study``) to act as the parent. Shared keys with no
+name-identifiable parent are *reported as unresolved*, not linked: surfacing the
+candidate to the user without inventing a relationship that might point the wrong
+way. (A future refinement could pick the parent by column-value uniqueness — the
+true primary-key signal — at the cost of reading the key columns.)
+
+The detector is a pure function over lightweight descriptors so it is trivially
+testable; ``metadata_generator`` maps its output back onto the real Field objects.
+"""
+
+import re
+from collections import defaultdict
+from typing import Dict, List, Tuple, TypedDict
+
+# A key-like column is ``<stem>_id`` (subject_id, hadm_id, study_id, ...). A bare
+# ``id`` is intentionally excluded: it is too generic to attribute to a parent by
+# name, and almost always denotes the *local* primary key rather than a foreign
+# key into another table.
+_KEY_RE = re.compile(r"^(?P<stem>.+)_id$", re.IGNORECASE)
+
+
+class RecordSetDescriptor(TypedDict):
+    """Minimal view of a RecordSet needed for foreign-key detection."""
+
+    id: str
+    name: str
+    columns: List[str]
+
+
+class ForeignKeyLink(TypedDict):
+    """A detected foreign key: ``child.column`` references ``parent.parent_column``."""
+
+    child_rs: str
+    column: str
+    parent_rs: str
+    parent_column: str
+
+
+class UnresolvedKey(TypedDict):
+    """A shared key column for which no parent RecordSet could be named."""
+
+    column: str
+    record_sets: List[str]
+
+
+def _parent_name_variants(stem: str) -> set:
+    """Return plausible parent table names for a key stem.
+
+    ``study_id`` -> a parent table called ``study``, ``studys``, or ``studies``.
+    Handles the common English pluralisations so name matching catches the usual
+    ``<entity>`` / ``<entity>s`` / ``<entity>(y->ies)`` conventions.
+    """
+    stem = stem.lower()
+    variants = {stem, stem + "s"}
+    if stem.endswith("y"):
+        variants.add(stem[:-1] + "ies")
+    if stem.endswith(("s", "x", "z", "ch", "sh")):
+        variants.add(stem + "es")
+    return variants
+
+
+def detect_foreign_keys(
+    record_sets: List[RecordSetDescriptor],
+) -> Tuple[List[ForeignKeyLink], List[UnresolvedKey]]:
+    """Detect foreign-key relationships between RecordSets by column name.
+
+    Args:
+        record_sets: descriptors with ``id``, ``name`` and top-level ``columns``.
+
+    Returns:
+        ``(links, unresolved)``. ``links`` are confident foreign keys (a parent
+        RecordSet was named); ``unresolved`` are shared key columns seen in two or
+        more RecordSets for which no parent could be identified by name — reported
+        so the caller can surface them rather than silently dropping the signal.
+        Both lists are deterministically ordered.
+    """
+    columns_to_holders: Dict[str, List[RecordSetDescriptor]] = defaultdict(list)
+    for rs in record_sets:
+        for col in rs["columns"]:
+            columns_to_holders[col].append(rs)
+
+    name_index: Dict[str, RecordSetDescriptor] = {}
+    for rs in record_sets:
+        # First RecordSet wins a given name; collisions are already disambiguated
+        # upstream, so this is just a stable lookup.
+        name_index.setdefault((rs["name"] or "").lower(), rs)
+
+    links: List[ForeignKeyLink] = []
+    unresolved: List[UnresolvedKey] = []
+
+    for col, holders in sorted(columns_to_holders.items()):
+        if len(holders) < 2:
+            continue  # not shared — nothing to link
+        match = _KEY_RE.match(col)
+        if not match:
+            continue  # not key-like (no ``_id`` suffix)
+
+        stem = match.group("stem")
+        # The parent is the RecordSet named after the stem (singular/plural) that
+        # also carries the key column itself. Requiring the column to be present
+        # keeps v1 coherent — it links same-named shared keys (the convention
+        # issue #51 describes, e.g. subject_id repeated across tables) and points
+        # the reference at a real field rather than a fabricated one. (A Rails-
+        # style parent whose own key is a bare ``id`` is a possible later
+        # extension; for now such a key, present only in the child, is skipped.)
+        parent = None
+        for variant in _parent_name_variants(stem):
+            candidate = name_index.get(variant)
+            if candidate is not None and col in candidate["columns"]:
+                parent = candidate
+                break
+
+        if parent is None:
+            unresolved.append(
+                {"column": col, "record_sets": [rs["id"] for rs in holders]}
+            )
+            continue
+
+        for rs in holders:
+            if rs["id"] == parent["id"]:
+                continue  # the parent does not reference itself
+            links.append(
+                {
+                    "child_rs": rs["id"],
+                    "column": col,
+                    "parent_rs": parent["id"],
+                    "parent_column": col,
+                }
+            )
+
+    return links, unresolved

--- a/src/croissant_baker/references.py
+++ b/src/croissant_baker/references.py
@@ -1,9 +1,9 @@
 """Heuristic foreign-key detection across RecordSets (Croissant ``cr:references``).
 
 Croissant can express a foreign key by giving a Field a ``references`` Source that
-points at another RecordSet's field. croissant-baker treats every file as an
-island today (see issue #51 and the inline TODO in ``metadata_generator``); this
-module adds an opt-in pass that links shared key columns across RecordSets.
+points at another RecordSet's field. Before this pass, croissant-baker described
+every table in isolation (see issue #51); this module adds an opt-in pass that
+links shared key columns across RecordSets.
 
 Design: **conservative, and it never guesses a direction.** A reference is emitted
 only when a shared key column has a parent RecordSet that can be identified *by
@@ -14,12 +14,27 @@ candidate to the user without inventing a relationship that might point the wron
 way. (A future refinement could pick the parent by column-value uniqueness — the
 true primary-key signal — at the cost of reading the key columns.)
 
+Two rules keep the emitted graph honest rather than merely plausible:
+
+* A name shared by more than one RecordSet identifies nobody, so it names no
+  parent. ``RecordSet.name`` carries no uniqueness guarantee — ``identifiers``
+  disambiguates ``id`` and leaves ``name`` alone, so ``study.csv`` and
+  ``study.tsv`` are both still named ``study`` — and electing one of them would
+  make its twin a child of itself.
+* A link that would close a cycle is refused. mlcroissant walks the references
+  as an operation graph, and a cycle makes *every* RecordSet in the document
+  unreadable while the document still validates. Columns are considered in name
+  order, so the first link of a mutually-keyed pair survives and the rest are
+  reported: deterministic, but alphabetical rather than a claim about the schema.
+
 The detector is a pure function over lightweight descriptors so it is trivially
 testable; ``metadata_generator`` maps its output back onto the real Field objects.
 """
 
 import re
-from collections import defaultdict
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Dict, List, Tuple, TypedDict
 
 # A key-like column is ``<stem>_id`` (subject_id, hadm_id, study_id, ...). A bare
@@ -46,27 +61,127 @@ class ForeignKeyLink(TypedDict):
     parent_column: str
 
 
+class Unlinkable(str, Enum):
+    """Why a shared key column was reported instead of linked.
+
+    ``str`` mixin so a reason serialises to its own value, as
+    :class:`croissant_baker.entries.Reason` does.
+    """
+
+    #: No RecordSet is named after the key's stem, or more than one is.
+    NO_PARENT = "no_parent"
+    #: A parent was identified, and linking to it would close a reference cycle.
+    WOULD_CYCLE = "would_cycle"
+
+
+UNLINKABLE_LABELS: Dict[Unlinkable, str] = {
+    Unlinkable.NO_PARENT: "no single record set is named after it",
+    Unlinkable.WOULD_CYCLE: "linking it would close a reference cycle",
+}
+
+
 class UnresolvedKey(TypedDict):
-    """A shared key column for which no parent RecordSet could be named."""
+    """A shared key column that was reported rather than linked."""
 
     column: str
     record_sets: List[str]
+    reason: Unlinkable
 
 
-def _parent_name_variants(stem: str) -> set:
-    """Return plausible parent table names for a key stem.
+@dataclass(frozen=True)
+class ReferenceReport:
+    """What the foreign-key pass linked, and what it declined to link.
 
-    ``study_id`` -> a parent table called ``study``, ``studys``, or ``studies``.
-    Handles the common English pluralisations so name matching catches the usual
-    ``<entity>`` / ``<entity>s`` / ``<entity>(y->ies)`` conventions.
+    Held by the generator and rendered by the CLI, the way
+    :class:`croissant_baker.scan.ScanReport` is: the library states what it
+    found, and only the CLI writes to a terminal. :meth:`summary_lines` is one
+    line by default, whatever the dataset, and names a column per line only
+    under ``verbose``.
+    """
+
+    links: List[ForeignKeyLink] = field(default_factory=list)
+    unresolved: List[UnresolvedKey] = field(default_factory=list)
+
+    def summary_lines(self, verbose: bool = False) -> List[str]:
+        """One line saying what was linked, and under ``verbose`` what was not.
+
+        The invitation to re-run is folded into that line rather than added as
+        its own ``Tip:``, because the coverage section above may already end in
+        one and two competing tips read as noise.
+        """
+        if not self.links and not self.unresolved:
+            return ["Foreign keys: none detected."]
+
+        line = f"Foreign keys: {len(self.links)} link(s)"
+        if self.unresolved:
+            line += f"; {len(self.unresolved)} shared key(s) not linked"
+            if not verbose:
+                line += " (re-run with --verbose to name them)"
+        lines = [line + "."]
+
+        if verbose:
+            lines.extend(
+                f"  {key['column']}: shared by {', '.join(key['record_sets'])}"
+                f" — {UNLINKABLE_LABELS[key['reason']]}"
+                for key in self.unresolved
+            )
+        return lines
+
+
+def _parent_name_variants(stem: str) -> List[str]:
+    """Plausible parent table names for a key stem, in the order they are tried.
+
+    ``study_id`` -> a parent table called ``study``, then ``studys``, then
+    ``studies``. Handles the common English pluralisations so name matching
+    catches the usual ``<entity>`` / ``<entity>s`` / ``<entity>(y->ies)``
+    conventions.
+
+    Ordered, and a list rather than a set, because the order *is* the tie-break
+    when a dataset holds more than one candidate: out of a set, iteration
+    followed the string hashes and the chosen parent moved with
+    ``PYTHONHASHSEED``. The exact stem wins, then the naive plural, then the
+    grammatical one. No two variants of a stem can coincide, so the list never
+    repeats itself.
     """
     stem = stem.lower()
-    variants = {stem, stem + "s"}
+    variants = [stem, stem + "s"]
     if stem.endswith("y"):
-        variants.add(stem[:-1] + "ies")
-    if stem.endswith(("s", "x", "z", "ch", "sh")):
-        variants.add(stem + "es")
+        variants.append(stem[:-1] + "ies")
+    elif stem.endswith(("s", "x", "z", "ch", "sh")):
+        variants.append(stem + "es")
     return variants
+
+
+def _unique_name_index(
+    record_sets: List[RecordSetDescriptor],
+) -> Dict[str, RecordSetDescriptor]:
+    """Look up a RecordSet by name, for the names that identify exactly one.
+
+    A name claimed by two RecordSets identifies neither. Taking the first would
+    elect a winner in filesystem discovery order and make its twin — the same
+    table in another format — a foreign-key child of itself.
+    """
+    counts = Counter((rs["name"] or "").lower() for rs in record_sets)
+    return {
+        (rs["name"] or "").lower(): rs
+        for rs in record_sets
+        if counts[(rs["name"] or "").lower()] == 1
+    }
+
+
+def _reaches(parents: Dict[str, List[str]], start: str, target: str) -> bool:
+    """Whether ``target`` is reachable from ``start`` by following references."""
+    seen: set = set()
+    stack = [start]
+    while stack:
+        node = stack.pop()
+        if node == target:
+            return True
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(parents.get(node, ()))
+    return False
 
 
 def detect_foreign_keys(
@@ -79,31 +194,36 @@ def detect_foreign_keys(
 
     Returns:
         ``(links, unresolved)``. ``links`` are confident foreign keys (a parent
-        RecordSet was named); ``unresolved`` are shared key columns seen in two or
-        more RecordSets for which no parent could be identified by name — reported
-        so the caller can surface them rather than silently dropping the signal.
-        Both lists are deterministically ordered.
+        RecordSet was named); ``unresolved`` are shared key columns seen in two
+        or more RecordSets that were reported rather than linked, each carrying
+        the reason — so the caller can surface them rather than silently
+        dropping the signal. Both lists are deterministically ordered, and
+        neither depends on the order the RecordSets arrived in.
     """
     columns_to_holders: Dict[str, List[RecordSetDescriptor]] = defaultdict(list)
     for rs in record_sets:
-        for col in rs["columns"]:
+        # dict.fromkeys, not the raw list: a column named twice in one RecordSet
+        # would otherwise let that RecordSet clear the "shared by two" gate alone.
+        for col in dict.fromkeys(rs["columns"]):
             columns_to_holders[col].append(rs)
 
-    name_index: Dict[str, RecordSetDescriptor] = {}
-    for rs in record_sets:
-        # First RecordSet wins a given name; collisions are already disambiguated
-        # upstream, so this is just a stable lookup.
-        name_index.setdefault((rs["name"] or "").lower(), rs)
+    name_index = _unique_name_index(record_sets)
 
     links: List[ForeignKeyLink] = []
     unresolved: List[UnresolvedKey] = []
+    # child id -> the RecordSets it already references, for the cycle guard.
+    parents: Dict[str, List[str]] = defaultdict(list)
 
-    for col, holders in sorted(columns_to_holders.items()):
-        if len(holders) < 2:
+    for col, holding in sorted(columns_to_holders.items()):
+        if len(holding) < 2:
             continue  # not shared — nothing to link
         match = _KEY_RE.match(col)
         if not match:
             continue  # not key-like (no ``_id`` suffix)
+
+        # Sorted by id, so neither the emitted links nor the reported record
+        # sets inherit the order the scan happened to discover files in.
+        holders = sorted(holding, key=lambda rs: rs["id"])
 
         stem = match.group("stem")
         # The parent is the RecordSet named after the stem (singular/plural) that
@@ -121,14 +241,17 @@ def detect_foreign_keys(
                 break
 
         if parent is None:
-            unresolved.append(
-                {"column": col, "record_sets": [rs["id"] for rs in holders]}
-            )
+            unresolved.append(_unresolved(col, holders, Unlinkable.NO_PARENT))
             continue
 
+        refused = False
         for rs in holders:
             if rs["id"] == parent["id"]:
                 continue  # the parent does not reference itself
+            if _reaches(parents, parent["id"], rs["id"]):
+                refused = True
+                continue  # would close a cycle; reported after the loop
+            parents[rs["id"]].append(parent["id"])
             links.append(
                 {
                     "child_rs": rs["id"],
@@ -138,4 +261,17 @@ def detect_foreign_keys(
                 }
             )
 
+        if refused:
+            unresolved.append(_unresolved(col, holders, Unlinkable.WOULD_CYCLE))
+
     return links, unresolved
+
+
+def _unresolved(
+    column: str, holders: List[RecordSetDescriptor], reason: Unlinkable
+) -> UnresolvedKey:
+    return {
+        "column": column,
+        "record_sets": [rs["id"] for rs in holders],
+        "reason": reason,
+    }

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,176 @@
+"""Foreign-key detection: the pure detector and end-to-end cr:references output."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
+from croissant_baker.references import detect_foreign_keys
+
+
+# ---------------------------------------------------------------------------
+# Pure detector
+# ---------------------------------------------------------------------------
+
+
+def _rs(rid: str, name: str, columns: list) -> dict:
+    return {"id": rid, "name": name, "columns": columns}
+
+
+def test_links_child_to_named_parent_same_column() -> None:
+    """A shared <stem>_id links to a parent table named after the stem."""
+    links, unresolved = detect_foreign_keys(
+        [
+            _rs("studies", "studies", ["study_id", "title"]),
+            _rs("samples", "samples", ["sample_id", "study_id", "value"]),
+        ]
+    )
+    assert unresolved == []
+    assert links == [
+        {
+            "child_rs": "samples",
+            "column": "study_id",
+            "parent_rs": "studies",
+            "parent_column": "study_id",
+        }
+    ]
+
+
+def test_parent_identified_by_plural_y_to_ies() -> None:
+    """`study_id` resolves a parent RecordSet named `studies` (y -> ies)."""
+    links, _ = detect_foreign_keys(
+        [
+            _rs("studies", "studies", ["study_id"]),
+            _rs("obs", "observations", ["study_id"]),
+        ]
+    )
+    assert [link["parent_rs"] for link in links] == ["studies"]
+
+
+def test_rails_style_bare_id_parent_not_linked_in_v1() -> None:
+    """v1 links same-named shared keys only.
+
+    A Rails-style parent (`study` with a bare `id`) whose child key (`study_id`)
+    lives only in the child is intentionally left alone — the key is not shared
+    under the same name, so there is nothing to match conservatively.
+    """
+    links, unresolved = detect_foreign_keys(
+        [
+            _rs("study", "study", ["id", "title"]),
+            _rs("samples", "samples", ["study_id"]),
+        ]
+    )
+    assert links == []
+    assert unresolved == []
+
+
+def test_unresolved_when_no_named_parent() -> None:
+    """A shared key with no name-matching parent is reported, not linked."""
+    links, unresolved = detect_foreign_keys(
+        [
+            _rs("patients", "patients", ["subject_id", "dob"]),
+            _rs("admissions", "admissions", ["subject_id", "hadm_id"]),
+        ]
+    )
+    assert links == []
+    assert unresolved == [
+        {"column": "subject_id", "record_sets": ["patients", "admissions"]}
+    ]
+
+
+def test_ignores_non_key_and_unshared_columns() -> None:
+    """Non-`_id` columns and keys present in only one table produce nothing."""
+    links, unresolved = detect_foreign_keys(
+        [
+            _rs("a", "a", ["value", "study_id"]),
+            _rs("b", "b", ["value", "note"]),  # shares 'value' (not key-like)
+        ]
+    )
+    assert links == []
+    assert unresolved == []
+
+
+def test_bare_id_is_not_a_foreign_key() -> None:
+    """A shared bare `id` column is too generic to treat as a foreign key."""
+    links, unresolved = detect_foreign_keys(
+        [_rs("a", "a", ["id"]), _rs("b", "b", ["id"])]
+    )
+    assert links == []
+    assert unresolved == []
+
+
+def test_single_record_set_has_no_links() -> None:
+    links, unresolved = detect_foreign_keys([_rs("a", "a", ["study_id"])])
+    assert links == [] and unresolved == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through MetadataGenerator
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def relational_dataset(tmp_path: Path) -> Path:
+    ds = tmp_path / "relational"
+    ds.mkdir()
+    (ds / "studies.csv").write_text("study_id,title\n1,Alpha\n2,Beta\n")
+    (ds / "samples.csv").write_text("sample_id,study_id,value\n10,1,0.5\n11,2,0.7\n")
+    return ds
+
+
+def _bake(ds: Path, **kwargs) -> dict:
+    return MetadataGenerator(
+        str(ds),
+        name="rel",
+        description="d",
+        creators=[{"name": "A"}],
+        date_published="2024-01-01",
+        **kwargs,
+    ).generate_metadata()
+
+
+def test_detect_references_emits_and_validates(
+    relational_dataset: Path, tmp_path: Path
+) -> None:
+    """With detection on, the child key references the parent and output validates."""
+    out = tmp_path / "c.jsonld"
+    gen = MetadataGenerator(
+        str(relational_dataset),
+        name="rel",
+        description="d",
+        creators=[{"name": "A"}],
+        date_published="2024-01-01",
+        detect_references=True,
+    )
+    gen.save_metadata(str(out), validate=True)  # must not raise
+
+    meta = json.loads(out.read_text())
+    fields = {
+        rs["name"]: {f["name"]: f for f in rs["field"]} for rs in meta["recordSet"]
+    }
+    ref = fields["samples"]["study_id"].get("references")
+    assert ref == {"field": {"@id": "studies/study_id"}}
+    # The parent's own key is not a self-reference.
+    assert "references" not in fields["studies"]["study_id"]
+
+
+def test_no_references_by_default(relational_dataset: Path) -> None:
+    """Detection is opt-in: default output carries no references."""
+    meta = _bake(relational_dataset)
+    for rs in meta["recordSet"]:
+        for field in rs["field"]:
+            assert "references" not in field
+
+
+def test_detection_is_deterministic(relational_dataset: Path) -> None:
+    """Reference detection does not introduce run-to-run variation."""
+
+    def dump() -> str:
+        return json.dumps(
+            _bake(relational_dataset, detect_references=True),
+            sort_keys=True,
+            default=serialize_datetime,
+        )
+
+    assert dump() == dump()

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -2,11 +2,23 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
+import mlcroissant as mlc
 import pytest
 
-from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
-from croissant_baker.references import detect_foreign_keys
+from croissant_baker.metadata_generator import (
+    MetadataGenerator,
+    _field_named,
+    serialize_datetime,
+)
+from croissant_baker.references import (
+    Unlinkable,
+    _parent_name_variants,
+    detect_foreign_keys,
+)
+
+from tests.helpers import cli
 
 
 # ---------------------------------------------------------------------------
@@ -48,6 +60,17 @@ def test_parent_identified_by_plural_y_to_ies() -> None:
     assert [link["parent_rs"] for link in links] == ["studies"]
 
 
+def test_parent_identified_by_es_plural() -> None:
+    """`box_id` resolves a parent named `boxes` (sibilant stem -> es)."""
+    links, _ = detect_foreign_keys(
+        [
+            _rs("boxes", "boxes", ["box_id"]),
+            _rs("items", "items", ["box_id"]),
+        ]
+    )
+    assert [link["parent_rs"] for link in links] == ["boxes"]
+
+
 def test_rails_style_bare_id_parent_not_linked_in_v1() -> None:
     """v1 links same-named shared keys only.
 
@@ -75,7 +98,11 @@ def test_unresolved_when_no_named_parent() -> None:
     )
     assert links == []
     assert unresolved == [
-        {"column": "subject_id", "record_sets": ["patients", "admissions"]}
+        {
+            "column": "subject_id",
+            "record_sets": ["admissions", "patients"],
+            "reason": Unlinkable.NO_PARENT,
+        }
     ]
 
 
@@ -105,6 +132,127 @@ def test_single_record_set_has_no_links() -> None:
     assert links == [] and unresolved == []
 
 
+def test_no_record_sets_at_all() -> None:
+    """The detector is asked to run before anyone counts the record sets."""
+    assert detect_foreign_keys([]) == ([], [])
+
+
+def test_a_column_repeated_in_one_record_set_is_not_shared() -> None:
+    """One RecordSet naming a column twice does not make the column shared."""
+    links, unresolved = detect_foreign_keys(
+        [_rs("a", "a", ["study_id", "study_id"]), _rs("b", "b", ["value"])]
+    )
+    assert links == []
+    assert unresolved == []
+
+
+# ---------------------------------------------------------------------------
+# Determinism of the tie-break
+# ---------------------------------------------------------------------------
+
+
+def test_parent_name_variants_are_an_ordered_list() -> None:
+    """The variants are tried in a fixed order, so the tie-break is fixed.
+
+    Regression guard: this returned a set, and with both `study` and `studies`
+    in one dataset the parent that won moved with ``PYTHONHASHSEED``. Asserting
+    the ordering itself rather than sweeping seeds keeps the guard exact — a
+    seed sweep would only catch the flip about half the time per seed.
+    """
+    variants = _parent_name_variants("study")
+    assert isinstance(variants, list)
+    assert variants[0] == "study"
+    assert variants.index("studys") < variants.index("studies")
+    assert _parent_name_variants("box") == ["box", "boxs", "boxes"]
+
+
+@pytest.mark.parametrize("order", [(0, 1, 2), (2, 1, 0), (1, 2, 0)])
+def test_exact_stem_wins_when_both_singular_and_plural_exist(order: tuple) -> None:
+    """With `study` and `studies` both present, the exact stem is the parent."""
+    record_sets = [
+        _rs("study", "study", ["study_id", "title"]),
+        _rs("studies", "studies", ["study_id", "label"]),
+        _rs("samples", "samples", ["sample_id", "study_id"]),
+    ]
+    links, _ = detect_foreign_keys([record_sets[i] for i in order])
+    assert {link["parent_rs"] for link in links} == {"study"}
+
+
+@pytest.mark.parametrize("order", [(0, 1, 2), (2, 1, 0)])
+def test_a_name_two_record_sets_share_identifies_neither(order: tuple) -> None:
+    """`study.csv` and `study.tsv` are both named `study`, so neither is parent.
+
+    Only ``id`` is disambiguated upstream, so a name can be claimed twice.
+    Electing either would make its twin — the same table in another format — a
+    foreign-key child of itself.
+    """
+    record_sets = [
+        _rs("study_csv", "study", ["study_id", "title"]),
+        _rs("study_tsv", "study", ["study_id", "title"]),
+        _rs("samples", "samples", ["sample_id", "study_id"]),
+    ]
+    links, unresolved = detect_foreign_keys([record_sets[i] for i in order])
+    assert links == []
+    assert unresolved == [
+        {
+            "column": "study_id",
+            "record_sets": ["samples", "study_csv", "study_tsv"],
+            "reason": Unlinkable.NO_PARENT,
+        }
+    ]
+
+
+def test_a_refused_link_is_reported_even_when_another_one_survives() -> None:
+    """A third table must not hide the refusal the first two produced.
+
+    ``a`` and ``b`` are mutually keyed; ``c`` is an ordinary child of ``b``.
+    The refused ``a -> b`` link is reported whether or not ``c -> b`` succeeds.
+    """
+    links, unresolved = detect_foreign_keys(
+        [
+            _rs("a", "a", ["a_id", "b_id"]),
+            _rs("b", "b", ["b_id", "a_id"]),
+            _rs("c", "c", ["c_id", "b_id"]),
+        ]
+    )
+    assert [(link["child_rs"], link["parent_rs"]) for link in links] == [
+        ("b", "a"),
+        ("c", "b"),
+    ]
+    assert unresolved == [
+        {
+            "column": "b_id",
+            "record_sets": ["a", "b", "c"],
+            "reason": Unlinkable.WOULD_CYCLE,
+        }
+    ]
+
+
+def test_a_link_that_would_close_a_cycle_is_refused() -> None:
+    """Two mutually-keyed tables keep one direction; the other is reported."""
+    links, unresolved = detect_foreign_keys(
+        [
+            _rs("studies", "studies", ["study_id", "site_id"]),
+            _rs("sites", "sites", ["site_id", "study_id"]),
+        ]
+    )
+    assert links == [
+        {
+            "child_rs": "studies",
+            "column": "site_id",
+            "parent_rs": "sites",
+            "parent_column": "site_id",
+        }
+    ]
+    assert unresolved == [
+        {
+            "column": "study_id",
+            "record_sets": ["sites", "studies"],
+            "reason": Unlinkable.WOULD_CYCLE,
+        }
+    ]
+
+
 # ---------------------------------------------------------------------------
 # End-to-end through MetadataGenerator
 # ---------------------------------------------------------------------------
@@ -119,6 +267,16 @@ def relational_dataset(tmp_path: Path) -> Path:
     return ds
 
 
+@pytest.fixture
+def unresolvable_dataset(tmp_path: Path) -> Path:
+    """Two tables sharing `subject_id`, with no table named after it."""
+    ds = tmp_path / "unresolvable"
+    ds.mkdir()
+    (ds / "patients.csv").write_text("subject_id,dob\n1,1990-01-01\n")
+    (ds / "admissions.csv").write_text("subject_id,hadm_id\n1,10\n")
+    return ds
+
+
 def _bake(ds: Path, **kwargs) -> dict:
     return MetadataGenerator(
         str(ds),
@@ -128,6 +286,11 @@ def _bake(ds: Path, **kwargs) -> dict:
         date_published="2024-01-01",
         **kwargs,
     ).generate_metadata()
+
+
+def _fields_by_record_set(meta: dict) -> dict:
+    """Fields keyed by RecordSet ``@id`` — names are not unique, ids are."""
+    return {rs["@id"]: {f["name"]: f for f in rs["field"]} for rs in meta["recordSet"]}
 
 
 def test_detect_references_emits_and_validates(
@@ -145,14 +308,58 @@ def test_detect_references_emits_and_validates(
     )
     gen.save_metadata(str(out), validate=True)  # must not raise
 
-    meta = json.loads(out.read_text())
-    fields = {
-        rs["name"]: {f["name"]: f for f in rs["field"]} for rs in meta["recordSet"]
-    }
+    fields = _fields_by_record_set(json.loads(out.read_text()))
     ref = fields["samples"]["study_id"].get("references")
     assert ref == {"field": {"@id": "studies/study_id"}}
     # The parent's own key is not a self-reference.
     assert "references" not in fields["studies"]["study_id"]
+
+
+def test_linked_record_sets_can_still_be_read(relational_dataset: Path) -> None:
+    """Validation is not readability, so read the records too.
+
+    A reference makes mlcroissant join the two record sets, and a document that
+    validates can still fail to produce a row — which is how a reference cycle
+    presents. Written inside the dataset so the relative ``contentUrl`` resolves.
+    """
+    out = relational_dataset / "c.jsonld"
+    MetadataGenerator(
+        str(relational_dataset),
+        name="rel",
+        description="d",
+        creators=[{"name": "A"}],
+        date_published="2024-01-01",
+        detect_references=True,
+    ).save_metadata(str(out), validate=False)
+
+    dataset = mlc.Dataset(str(out))
+    assert len(list(dataset.records("samples"))) == 2
+
+
+def test_mutually_keyed_tables_stay_readable(tmp_path: Path) -> None:
+    """The cycle guard is what keeps a denormalised pair readable.
+
+    Without it both record sets raise ``NetworkXUnfeasible`` from mlcroissant's
+    operation graph, while the document still validates.
+    """
+    ds = tmp_path / "mutual"
+    ds.mkdir()
+    (ds / "studies.csv").write_text("study_id,site_id\n1,7\n2,8\n")
+    (ds / "sites.csv").write_text("site_id,study_id\n7,1\n8,2\n")
+
+    out = ds / "c.jsonld"
+    MetadataGenerator(
+        str(ds),
+        name="mutual",
+        description="d",
+        creators=[{"name": "A"}],
+        date_published="2024-01-01",
+        detect_references=True,
+    ).save_metadata(str(out), validate=True)
+
+    dataset = mlc.Dataset(str(out))
+    assert len(list(dataset.records("studies"))) == 2
+    assert len(list(dataset.records("sites"))) == 2
 
 
 def test_no_references_by_default(relational_dataset: Path) -> None:
@@ -163,8 +370,8 @@ def test_no_references_by_default(relational_dataset: Path) -> None:
             assert "references" not in field
 
 
-def test_detection_is_deterministic(relational_dataset: Path) -> None:
-    """Reference detection does not introduce run-to-run variation."""
+def test_detection_is_idempotent(relational_dataset: Path) -> None:
+    """Baking the same dataset twice in one process produces the same bytes."""
 
     def dump() -> str:
         return json.dumps(
@@ -174,3 +381,172 @@ def test_detection_is_deterministic(relational_dataset: Path) -> None:
         )
 
     assert dump() == dump()
+
+
+def test_a_missing_field_is_an_error_not_a_dropped_link() -> None:
+    """The lookup raises rather than skipping.
+
+    Every name it is given was copied out of a descriptor built from these very
+    Field objects, so a miss is a broken invariant — and losing a link quietly
+    is how a heuristic feature stops being reviewable.
+    """
+    record_set = SimpleNamespace(id="studies", fields=[SimpleNamespace(name="title")])
+    with pytest.raises(KeyError, match="study_id"):
+        _field_named(record_set, "study_id")
+
+
+# ---------------------------------------------------------------------------
+# The dataset the feature was reviewed against
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mimic_demo_dir() -> Path:
+    """Path to the bundled MIMIC-IV demo dataset."""
+    path = (
+        Path(__file__).parent
+        / "data"
+        / "input"
+        / "mimiciv_demo"
+        / "physionet.org"
+        / "files"
+        / "mimic-iv-demo"
+        / "2.2"
+    )
+    if not path.exists():
+        pytest.skip(f"MIMIC-IV demo dataset not found at {path}")
+    return path
+
+
+def test_the_mimic_demo_keeps_the_links_it_was_reviewed_with(
+    mimic_demo_dir: Path,
+) -> None:
+    """Pin the real-dataset numbers, which no synthetic fixture would notice.
+
+    ``subject_id`` is among the unresolved: MIMIC calls that table ``patients``,
+    not ``subjects``, and this pass will not link a parent it cannot name. That
+    is the conservatism working, and it is worth pinning too — a heuristic that
+    quietly starts linking more is the failure mode here.
+    """
+    gen = MetadataGenerator(str(mimic_demo_dir), name="mimic", detect_references=True)
+    gen.generate_metadata()
+    report = gen.reference_report
+
+    assert len(report.links) == 14
+    assert [key["column"] for key in report.unresolved] == [
+        "hadm_id",
+        "order_provider_id",
+        "stay_id",
+        "subject_id",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The report the CLI reads
+# ---------------------------------------------------------------------------
+
+
+def test_no_report_when_the_pass_did_not_run(relational_dataset: Path) -> None:
+    """None, not empty: the pass did not run rather than found nothing."""
+    gen = MetadataGenerator(str(relational_dataset), name="rel")
+    gen.generate_metadata()
+    assert gen.reference_report is None
+
+
+def test_report_is_empty_when_there_is_nothing_to_link(tmp_path: Path) -> None:
+    """A single-table dataset still gets a report — an empty one."""
+    ds = tmp_path / "lonely"
+    ds.mkdir()
+    (ds / "studies.csv").write_text("study_id,title\n1,Alpha\n")
+
+    gen = MetadataGenerator(str(ds), name="lonely", detect_references=True)
+    gen.generate_metadata()
+
+    report = gen.reference_report
+    assert report is not None
+    assert report.links == [] and report.unresolved == []
+    assert report.summary_lines() == ["Foreign keys: none detected."]
+
+
+def test_report_names_unresolved_keys_only_when_verbose(
+    unresolvable_dataset: Path,
+) -> None:
+    gen = MetadataGenerator(str(unresolvable_dataset), name="u", detect_references=True)
+    gen.generate_metadata()
+    report = gen.reference_report
+
+    assert report.summary_lines() == [
+        "Foreign keys: 0 link(s); 1 shared key(s) not linked "
+        "(re-run with --verbose to name them)."
+    ]
+    assert report.summary_lines(verbose=True) == [
+        "Foreign keys: 0 link(s); 1 shared key(s) not linked.",
+        "  subject_id: shared by admissions, patients"
+        " — no single record set is named after it",
+    ]
+
+
+def test_report_names_a_refused_cycle_under_verbose(tmp_path: Path) -> None:
+    """The cycle refusal reaches the user with a reason of its own."""
+    ds = tmp_path / "mutual"
+    ds.mkdir()
+    (ds / "studies.csv").write_text("study_id,site_id\n1,7\n")
+    (ds / "sites.csv").write_text("site_id,study_id\n7,1\n")
+
+    gen = MetadataGenerator(str(ds), name="m", detect_references=True)
+    gen.generate_metadata()
+
+    assert gen.reference_report.summary_lines(verbose=True) == [
+        "Foreign keys: 1 link(s); 1 shared key(s) not linked.",
+        "  study_id: shared by sites, studies"
+        " — linking it would close a reference cycle",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The CLI, which is the only thing the user actually sees
+# ---------------------------------------------------------------------------
+
+
+def test_cli_says_nothing_about_references_without_the_flag(
+    unresolvable_dataset: Path, tmp_path: Path
+) -> None:
+    result = cli(unresolvable_dataset, tmp_path / "out.jsonld")
+
+    assert result.exit_code == 0
+    assert "Foreign keys" not in result.stdout
+
+
+def test_cli_reports_unresolved_keys_without_naming_them(
+    unresolvable_dataset: Path, tmp_path: Path
+) -> None:
+    """The default line is fixed-size: a count, and how to see the detail."""
+    result = cli(unresolvable_dataset, tmp_path / "out.jsonld", "--detect-references")
+
+    assert result.exit_code == 0
+    assert "Foreign keys: 0 link(s); 1 shared key(s) not linked" in result.stdout
+    assert "subject_id" not in result.stdout
+
+
+def test_cli_names_unresolved_keys_under_verbose(
+    unresolvable_dataset: Path, tmp_path: Path
+) -> None:
+    result = cli(
+        unresolvable_dataset,
+        tmp_path / "out.jsonld",
+        "--detect-references",
+        "--verbose",
+    )
+
+    assert result.exit_code == 0
+    assert (
+        "  subject_id: shared by admissions, patients"
+        " — no single record set is named after it" in result.stdout
+    )
+
+
+def test_cli_states_the_links_it_made(relational_dataset: Path, tmp_path: Path) -> None:
+    result = cli(relational_dataset, tmp_path / "out.jsonld", "--detect-references")
+
+    assert result.exit_code == 0
+    assert "Foreign keys: 1 link(s)." in result.stdout


### PR DESCRIPTION
Draft PR opened by **Chimera** (an autonomous code agent operated by @elementalcollision), as part of a review of croissant-baker. Opened as a **draft** for maintainer review — especially on the design choice flagged at the bottom.

Addresses **#51** (and the inline `# TODO … references: detect foreign-key columns` in `generate_metadata`).

## What

Today every file becomes an isolated RecordSet; relational datasets lose their join structure. This adds an **opt-in** detector — `--detect-references` (`detect_references=True`) — that links shared key columns across RecordSets with Croissant `cr:references`.

It is deliberately conservative and **never guesses a direction**:

- A column is a foreign-key candidate when it's named `<stem>_id` and appears in **≥2 RecordSets**. A bare `id` is excluded (too generic).
- The **parent** is the RecordSet named after the stem (singular/plural: `study_id` → `studies`/`study`) that also carries the key column. Every other holder's field gets `references → parent.<stem>_id`.
- Shared keys with **no name-identifiable parent** are *logged as unresolved, not linked* — surfacing the candidate without inventing a relationship that might point the wrong way.

Example (`studies.csv` + `samples.csv`, both with `study_id`):

```json
"field": [
  { "@id": "samples/study_id", "name": "study_id",
    "references": { "field": { "@id": "studies/study_id" } } }
]
```

## Design

- Detection is a **pure function** in a new `references.py` (trivially unit-testable); `metadata_generator` maps its output onto the real `Field` objects via the native `mlc.Source(field=…)` API — no JSON patching.
- **Off by default** — existing output is unchanged; the committed `tests/data/output/*.jsonld` are untouched.

## Tests

`tests/test_references.py`: detector unit tests (same-name match, `y→ies` plural, unresolved reporting, rejection of non-key / unshared / bare-`id` columns) and end-to-end (emission, **mlcroissant validation**, opt-in default, determinism). Full suite: **279 passed**. ruff clean.

## Open question for maintainers (why it's a draft)

This v1 picks the parent **by name**. That cleanly handles the same-named-key convention #51 describes (e.g. OMOP/MEDS-style repeated `subject_id`), but it will **not** link cases where the parent's name doesn't match the stem, notably MIMIC's `subject_id → patients` (there's no `subjects` table). The robust fix is to pick the parent by **column-value uniqueness** (the actual primary-key signal), which would catch those at the cost of reading the candidate key columns. I scoped v1 to the safe, no-extra-IO heuristic on purpose; happy to extend to uniqueness-based detection if you'd prefer that direction.
