### PR TITLE
feat: add discovery and access fields with a Bioschemas profile

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,7 +40,7 @@ $ croissant-baker [OPTIONS] COMMAND [ARGS]...
 * `--conditions-of-access TEXT`: How access is obtained, in free text. Example: 'Controlled access: Data Access Agreement via the Data Access Committee'.
 * `--is-accessible-for-free / --not-accessible-for-free`: Whether the data can be had without payment or an access agreement. Omit to leave the field out.
 * `--included-in-data-catalog TEXT`: URL of a catalog entry listing this dataset (e.g., 'https://datacatalog.ccdi.cancer.gov/').
-* `--profile TEXT`: Additional profile to declare in conformsTo. One of: bioschemas. Declares the profile; it does not validate against it. Repeatable.
+* `--profile TEXT`: Additional profile to declare in conformsTo. One of: bioschemas. The bake is refused if the document lacks the profile's minimum fields. Repeat or comma-delimit.
 * `--field-mappings FILE`: YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\n  <col>:\n    equivalent_property: <URI>\n    data_types: [<URI>, ...]'. Note: column names match across ALL RecordSets, so 'id' applies to every 'id' column in the dataset.
 * `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Matches by bare column name across all RecordSets; a warning prints if a name resolves to multiple fields. Repeatable; combine with --field-mappings (flags override YAML).
 * `--count-csv-rows`: Count exact row numbers for CSV files (slow for large datasets)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,7 @@ $ croissant-baker [OPTIONS] COMMAND [ARGS]...
 * `--identifier TEXT`: Accession or persistent identifier the dataset is known by (e.g., 'phs000218.v1.p1', 'EGAS00001000255', a DOI). Repeat or comma-delimit.
 * `--conditions-of-access TEXT`: How access is obtained, in free text. Example: 'Controlled access: Data Access Agreement via the Data Access Committee'.
 * `--is-accessible-for-free / --not-accessible-for-free`: Whether the data can be had without payment or an access agreement. Omit to leave the field out.
-* `--included-in-data-catalog TEXT`: URL of a catalog entry listing this dataset (e.g., 'https://datacatalog.ccdi.cancer.gov/').
+* `--included-in-data-catalog TEXT`: URL of a catalog entry listing this dataset. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'https://datacatalog.ccdi.cancer.gov/'.
 * `--profile TEXT`: Additional profile to declare in conformsTo. One of: bioschemas. The bake is refused if the document lacks the profile's minimum fields. Repeat or comma-delimit.
 * `--field-mappings FILE`: YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\n  <col>:\n    equivalent_property: <URI>\n    data_types: [<URI>, ...]'. Note: column names match across ALL RecordSets, so 'id' applies to every 'id' column in the dataset.
 * `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Matches by bare column name across all RecordSets; a warning prints if a name resolves to multiple fields. Repeatable; combine with --field-mappings (flags override YAML).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,11 @@ $ croissant-baker [OPTIONS] COMMAND [ARGS]...
 * `--is-live-dataset`: Mark the dataset as a live, evolving stream (e.g., a continuously-appended log).
 * `--temporal-coverage TEXT`: Time period the data covers. ISO 8601 recommended: '2008/2019' (interval) or '2023-01-15' (point).
 * `--usage-info TEXT`: URI pointing to a usage or consent policy. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term).
+* `--identifier TEXT`: Accession or persistent identifier the dataset is known by (e.g., 'phs000218.v1.p1', 'EGAS00001000255', a DOI). Repeat or comma-delimit.
+* `--conditions-of-access TEXT`: How access is obtained, in free text. Example: 'Controlled access: Data Access Agreement via the Data Access Committee'.
+* `--is-accessible-for-free / --not-accessible-for-free`: Whether the data can be had without payment or an access agreement. Omit to leave the field out.
+* `--included-in-data-catalog TEXT`: URL of a catalog entry listing this dataset (e.g., 'https://datacatalog.ccdi.cancer.gov/').
+* `--profile TEXT`: Additional profile to declare in conformsTo. One of: bioschemas. Declares the profile; it does not validate against it. Repeatable.
 * `--field-mappings FILE`: YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\n  <col>:\n    equivalent_property: <URI>\n    data_types: [<URI>, ...]'. Note: column names match across ALL RecordSets, so 'id' applies to every 'id' column in the dataset.
 * `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Matches by bare column name across all RecordSets; a warning prints if a name resolves to multiple fields. Repeatable; combine with --field-mappings (flags override YAML).
 * `--count-csv-rows`: Count exact row numbers for CSV files (slow for large datasets)

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -22,6 +22,7 @@ from croissant_baker.metadata_generator import (
     MetadataGenerator,
     PROFILE_CONFORMS_TO,
     RAI_CONFORMS_TO,
+    normalize_profiles,
     serialize_datetime,
 )
 from croissant_baker import compression
@@ -315,30 +316,45 @@ def _merge_field_mapping_flags(
 _URI_SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*:")
 
 
-def _validate_uri(option_name: str, value: Optional[str]) -> None:
-    """Reject strings that don't start with an RFC 3986 URI scheme.
+def _uri_option(
+    ctx: typer.Context, param: typer.CallbackParam, value: Optional[str]
+) -> Optional[str]:
+    """Strip a URI-valued option, then reject strings with no URI scheme.
 
     Catches free text like 'see license file' but accepts http(s)://, urn:,
-    did:, mailto:, and any other valid scheme. schema.org/usageInfo accepts
+    did:, mailto:, and any other valid scheme — schema.org/usageInfo accepts
     URLs broadly, not just web URLs.
+
+    A parse-time callback rather than a check in the command body: Typer runs
+    it before ``--dry-run`` returns early, and a refusal renders as an invalid
+    option instead of being swallowed by the broad handler and reported as an
+    unexpected error. Normalising first means a blank value is absent rather
+    than a URI check nobody asked for.
     """
-    if value is None:
-        return
-    if not _URI_SCHEME.match(value):
+    value = _normalize_optional_text(value)
+    if value is not None and not _URI_SCHEME.match(value):
         raise typer.BadParameter(
-            f"{option_name} must be a URI starting with a scheme "
-            f"(e.g. https://, urn:, did:, mailto:), got {value!r}"
+            "must be a URI starting with a scheme "
+            f"(e.g. https://, urn:, did:, mailto:), got {value!r}",
+            ctx=ctx,
+            param=param,
         )
+    return value
 
 
-def _validate_profiles(values: Optional[List[str]]) -> None:
-    """Reject profile names the generator has no conformsTo URI for."""
-    unknown = sorted(set(values or []) - set(PROFILE_CONFORMS_TO))
-    if unknown:
-        raise typer.BadParameter(
-            f"--profile must be one of: {', '.join(sorted(PROFILE_CONFORMS_TO))}; "
-            f"got {', '.join(repr(name) for name in unknown)}"
-        )
+def _profile_option(
+    ctx: typer.Context, param: typer.CallbackParam, value: Optional[List[str]]
+) -> Optional[List[str]]:
+    """Normalise and check --profile while Typer parses, for the same reasons.
+
+    The rule belongs to the generator, which every caller goes through; this
+    only translates its refusal into the CLI's own error type so the message
+    is worded once.
+    """
+    try:
+        return normalize_profiles(list(value or []))
+    except ValueError as e:
+        raise typer.BadParameter(str(e), ctx=ctx, param=param)
 
 
 def _validate_iso_datetimes(option_name: str, values: Optional[List[str]]) -> None:
@@ -557,6 +573,7 @@ def main(
         None,
         "--usage-info",
         help="URI pointing to a usage or consent policy. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term).",
+        callback=_uri_option,
     ),
     identifier: Optional[List[str]] = typer.Option(
         None,
@@ -581,7 +598,8 @@ def main(
     profile: Optional[List[str]] = typer.Option(
         None,
         "--profile",
-        help=f"Additional profile to declare in conformsTo. One of: {', '.join(sorted(PROFILE_CONFORMS_TO))}. Declares the profile; it does not validate against it. Repeatable.",
+        help=f"Additional profile to declare in conformsTo. One of: {', '.join(sorted(PROFILE_CONFORMS_TO))}. Repeat or comma-delimit.",
+        callback=_profile_option,
     ),
     field_mappings: Optional[Path] = typer.Option(
         None,
@@ -913,11 +931,6 @@ def main(
                     err=True,
                 )
 
-        _validate_uri("--usage-info", usage_info)
-        # Normalise before validating, so the names checked here are the ones
-        # the generator is handed rather than the raw argv strings.
-        profiles = _normalize_optional_text_list(profile)
-        _validate_profiles(profiles)
         merged_field_mappings = _merge_field_mapping_flags(
             _load_field_mappings(field_mappings), field_mapping
         )
@@ -948,7 +961,7 @@ def main(
             conditions_of_access=conditions_of_access,
             is_accessible_for_free=is_accessible_for_free,
             included_in_data_catalog=included_in_data_catalog,
-            profiles=profiles,
+            profiles=profile,
             field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
             max_workers=jobs or None,

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -20,6 +20,7 @@ from rich.progress import (
 
 from croissant_baker.metadata_generator import (
     MetadataGenerator,
+    PROFILE_CONFORMS_TO,
     RAI_CONFORMS_TO,
     serialize_datetime,
 )
@@ -330,6 +331,16 @@ def _validate_uri(option_name: str, value: Optional[str]) -> None:
         )
 
 
+def _validate_profiles(values: Optional[List[str]]) -> None:
+    """Reject profile names the generator has no conformsTo URI for."""
+    unknown = sorted(set(values or []) - set(PROFILE_CONFORMS_TO))
+    if unknown:
+        raise typer.BadParameter(
+            f"--profile must be one of: {', '.join(sorted(PROFILE_CONFORMS_TO))}; "
+            f"got {', '.join(repr(name) for name in unknown)}"
+        )
+
+
 def _validate_iso_datetimes(option_name: str, values: Optional[List[str]]) -> None:
     """Validate repeated date/datetime options and raise a CLI-friendly error."""
     if not values:
@@ -546,6 +557,31 @@ def main(
         None,
         "--usage-info",
         help="URI pointing to a usage or consent policy. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term).",
+    ),
+    identifier: Optional[List[str]] = typer.Option(
+        None,
+        "--identifier",
+        help="Accession or persistent identifier the dataset is known by (e.g., 'phs000218.v1.p1', 'EGAS00001000255', a DOI). Repeat or comma-delimit.",
+    ),
+    conditions_of_access: Optional[str] = typer.Option(
+        None,
+        "--conditions-of-access",
+        help="How access is obtained, in free text. Example: 'Controlled access: Data Access Agreement via the Data Access Committee'.",
+    ),
+    is_accessible_for_free: Optional[bool] = typer.Option(
+        None,
+        "--is-accessible-for-free/--not-accessible-for-free",
+        help="Whether the data can be had without payment or an access agreement. Omit to leave the field out.",
+    ),
+    included_in_data_catalog: Optional[str] = typer.Option(
+        None,
+        "--included-in-data-catalog",
+        help="URL of a catalog entry listing this dataset (e.g., 'https://datacatalog.ccdi.cancer.gov/').",
+    ),
+    profile: Optional[List[str]] = typer.Option(
+        None,
+        "--profile",
+        help=f"Additional profile to declare in conformsTo. One of: {', '.join(sorted(PROFILE_CONFORMS_TO))}. Declares the profile; it does not validate against it. Repeatable.",
     ),
     field_mappings: Optional[Path] = typer.Option(
         None,
@@ -878,6 +914,7 @@ def main(
                 )
 
         _validate_uri("--usage-info", usage_info)
+        _validate_profiles(profile)
         merged_field_mappings = _merge_field_mapping_flags(
             _load_field_mappings(field_mappings), field_mapping
         )
@@ -904,6 +941,11 @@ def main(
             is_live_dataset=is_live_dataset or None,
             temporal_coverage=temporal_coverage,
             usage_info=usage_info,
+            identifier=_split_csv_list(identifier),
+            conditions_of_access=conditions_of_access,
+            is_accessible_for_free=is_accessible_for_free,
+            included_in_data_catalog=included_in_data_catalog,
+            profiles=_normalize_optional_text_list(profile),
             field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
             max_workers=jobs or None,

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -24,7 +24,7 @@ from croissant_baker.metadata_generator import (
     RAI_CONFORMS_TO,
     normalize_profiles,
     serialize_datetime,
-    url_is_iri_safe,
+    url_has_whitespace,
 )
 from croissant_baker import compression
 from croissant_baker.files import discover_files
@@ -941,9 +941,12 @@ def main(
                     err=True,
                 )
 
-        # Said before the bake rather than after it, so the user still reads
-        # it when a declared profile refuses the document for the missing @id.
-        if url and not url_is_iri_safe(url):
+        # The generator logs this too, for callers who configure logging; a
+        # terminal user has none, since the package ships a NullHandler and
+        # nothing here adds one. Said before the bake rather than after it, so
+        # it is still on screen when a declared profile refuses the document
+        # for the missing @id.
+        if url and url_has_whitespace(url):
             typer.echo(
                 f"Warning: --url {url!r} contains whitespace, so no @id was "
                 "emitted for the dataset.\n"

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -914,7 +914,10 @@ def main(
                 )
 
         _validate_uri("--usage-info", usage_info)
-        _validate_profiles(profile)
+        # Normalise before validating, so the names checked here are the ones
+        # the generator is handed rather than the raw argv strings.
+        profiles = _normalize_optional_text_list(profile)
+        _validate_profiles(profiles)
         merged_field_mappings = _merge_field_mapping_flags(
             _load_field_mappings(field_mappings), field_mapping
         )
@@ -945,7 +948,7 @@ def main(
             conditions_of_access=conditions_of_access,
             is_accessible_for_free=is_accessible_for_free,
             included_in_data_catalog=included_in_data_catalog,
-            profiles=_normalize_optional_text_list(profile),
+            profiles=profiles,
             field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
             max_workers=jobs or None,

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -322,7 +322,7 @@ def _uri_option(
     """Strip a URI-valued option, then reject strings with no URI scheme.
 
     Catches free text like 'see license file' but accepts http(s)://, urn:,
-    did:, mailto:, and any other valid scheme — schema.org/usageInfo accepts
+    did:, mailto:, and any other valid scheme. schema.org/usageInfo accepts
     URLs broadly, not just web URLs.
 
     A parse-time callback rather than a check in the command body: Typer runs

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -24,6 +24,7 @@ from croissant_baker.metadata_generator import (
     RAI_CONFORMS_TO,
     normalize_profiles,
     serialize_datetime,
+    url_is_iri_safe,
 )
 from croissant_baker import compression
 from croissant_baker.files import discover_files
@@ -931,6 +932,17 @@ def main(
                     "Warning: --count-csv-rows has no effect: no CSV files found in dataset",
                     err=True,
                 )
+
+        # Said before the bake rather than after it, so the user still reads
+        # it when a declared profile refuses the document for the missing @id.
+        if url and not url_is_iri_safe(url):
+            typer.echo(
+                f"Warning: --url {url!r} contains whitespace, so no @id was "
+                "emitted for the dataset.\n"
+                "  Percent-encode the whitespace (a space becomes %20) to give "
+                "the document an identifier.",
+                err=True,
+            )
 
         merged_field_mappings = _merge_field_mapping_flags(
             _load_field_mappings(field_mappings), field_mapping

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -594,6 +594,7 @@ def main(
         None,
         "--included-in-data-catalog",
         help="URL of a catalog entry listing this dataset (e.g., 'https://datacatalog.ccdi.cancer.gov/').",
+        callback=_uri_option,
     ),
     profile: Optional[List[str]] = typer.Option(
         None,
@@ -958,7 +959,7 @@ def main(
             temporal_coverage=temporal_coverage,
             usage_info=usage_info,
             identifier=_split_csv_list(identifier),
-            conditions_of_access=conditions_of_access,
+            conditions_of_access=_normalize_optional_text(conditions_of_access),
             is_accessible_for_free=is_accessible_for_free,
             included_in_data_catalog=included_in_data_catalog,
             profiles=profile,

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -602,7 +602,7 @@ def main(
     included_in_data_catalog: Optional[str] = typer.Option(
         None,
         "--included-in-data-catalog",
-        help="URL of a catalog entry listing this dataset (e.g., 'https://datacatalog.ccdi.cancer.gov/').",
+        help="URL of a catalog entry listing this dataset. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'https://datacatalog.ccdi.cancer.gov/'.",
         callback=_uri_option,
     ),
     profile: Optional[List[str]] = typer.Option(

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -599,7 +599,7 @@ def main(
     profile: Optional[List[str]] = typer.Option(
         None,
         "--profile",
-        help=f"Additional profile to declare in conformsTo. One of: {', '.join(sorted(PROFILE_CONFORMS_TO))}. Repeat or comma-delimit.",
+        help=f"Additional profile to declare in conformsTo. One of: {', '.join(sorted(PROFILE_CONFORMS_TO))}. The bake is refused if the document lacks the profile's minimum fields. Repeat or comma-delimit.",
         callback=_profile_option,
     ),
     field_mappings: Optional[Path] = typer.Option(

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -331,7 +331,12 @@ def _uri_option(
     option instead of being swallowed by the broad handler and reported as an
     unexpected error. Normalising first means a blank value is absent rather
     than a URI check nobody asked for.
+
+    Resilient parsing is shell completion and the like working out what the
+    command line means; it must never raise, so the value goes back untouched.
     """
+    if ctx.resilient_parsing:
+        return value
     value = _normalize_optional_text(value)
     if value is not None and not _URI_SCHEME.match(value):
         raise typer.BadParameter(
@@ -350,12 +355,15 @@ def _profile_option(
 
     The rule belongs to the generator, which every caller goes through; this
     only translates its refusal into the CLI's own error type so the message
-    is worded once.
+    is worded once. Resilient parsing gets the value back untouched, for the
+    same reason as above.
     """
+    if ctx.resilient_parsing:
+        return value
     try:
         return normalize_profiles(list(value or []))
     except ValueError as e:
-        raise typer.BadParameter(str(e), ctx=ctx, param=param)
+        raise typer.BadParameter(str(e), ctx=ctx, param=param) from e
 
 
 def _validate_iso_datetimes(option_name: str, values: Optional[List[str]]) -> None:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -57,12 +57,23 @@ RAI_CONFORMS_TO = "http://mlcommons.org/croissant/RAI/1.0"
 BIOSCHEMAS_CONFORMS_TO = "https://bioschemas.org/profiles/Dataset/1.0-RELEASE"
 
 # Profiles a document can additionally declare, by the name --profile takes.
-# A new profile is one entry here: the CLI validates against these keys and
-# the generator declares the URI alongside CROISSANT_CONFORMS_TO. Nothing else
-# in the document changes, so declaring a profile is a claim about the
-# vocabulary, not a validation against it.
+# A new profile is two entries: the URI declared alongside CROISSANT_CONFORMS_TO
+# here, and the fields the profile requires in PROFILE_MINIMUM_KEYS below.
 PROFILE_CONFORMS_TO = {
     "bioschemas": BIOSCHEMAS_CONFORMS_TO,
+}
+
+# Emitted keys a document must carry before it may declare each profile.
+# Declaring one is a claim a SHACL validator will check, so a document that
+# names a profile and then omits what the profile lists as minimum scores
+# worse than one that declares nothing. The generator refuses instead.
+#
+# Bioschemas Dataset 1.0-RELEASE lists ten minimum fields. The five here are
+# the ones a bake can lack; @context, @type and name are always written, @id
+# follows from url, and dct:conformsTo is what the declaration itself adds.
+# https://bioschemas.org/profiles/Dataset/1.0-RELEASE
+PROFILE_MINIMUM_KEYS = {
+    "bioschemas": ("description", "identifier", "keywords", "license", "url"),
 }
 
 
@@ -275,6 +286,9 @@ class MetadataGenerator:
                 ``PROFILE_CONFORMS_TO``. A list, or one name as a bare
                 string; either form may carry comma-separated names.
                 Normalised by ``normalize_profiles`` at construction.
+                ``generate_metadata`` refuses a document that declares a
+                profile without the fields ``PROFILE_MINIMUM_KEYS`` lists
+                for it.
             field_mappings: Per-column overrides keyed by field name. Each value
                 is a dict with optional ``equivalent_property`` (vocab URI) and
                 ``data_types`` (list of vocab URIs). Used to link columns to
@@ -384,6 +398,11 @@ class MetadataGenerator:
             progress_callback: Optional callback with signature
                 (completed: int, total: int, file_path: str) -> None
                 invoked once per file as it finishes extraction.
+
+        Raises:
+            ValueError: If nothing in the dataset could be described, or a
+                declared profile's minimum fields are missing from the
+                document that was assembled.
         """
         entries = scan_directory(
             str(self.dataset_path),
@@ -650,7 +669,36 @@ class MetadataGenerator:
             }
         if self.field_mappings:
             _apply_field_mappings(result, self.field_mappings)
+        self._assert_profile_minimums(result)
         return result
+
+    def _assert_profile_minimums(self, document: dict) -> None:
+        """Refuse to declare a profile whose minimum fields are missing.
+
+        Read off the assembled document rather than the constructor
+        arguments, because what reaches the file is not always what was
+        passed: ``description`` is generated when none was given, ``license``
+        is defaulted, and ``@id`` is injected from ``url``. The check has to
+        agree with what a validator will read.
+
+        Raises:
+            ValueError: naming every missing field, so one run tells the
+                caller everything they have to supply.
+        """
+        for profile in self.profiles or []:
+            missing = [
+                key
+                for key in PROFILE_MINIMUM_KEYS.get(profile, ())
+                if not document.get(key)
+            ]
+            if missing:
+                raise ValueError(
+                    f"Profile '{profile}' requires fields this document does "
+                    f"not carry: {', '.join(missing)}. They are minimum fields "
+                    "of the profile, so declaring it without them leaves the "
+                    "document failing validation against what it claims. "
+                    "Supply them, or drop the profile."
+                )
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -659,8 +659,15 @@ class MetadataGenerator:
         # and it is what Bioschemas expects there. A url no IRI can be built
         # from is skipped rather than written: the CLI says so on stderr, and
         # a declared profile that requires @id refuses the bake outright.
+        # Written beside the other node keywords, where a reader looks for the
+        # subject of the graph, rather than trailing the record sets.
         if url_is_iri_safe(self.url):
-            result["@id"] = self.url
+            result = {
+                "@context": result.pop("@context"),
+                "@type": result.pop("@type"),
+                "@id": self.url,
+                **result,
+            }
         if self.alternate_name is not None:
             result["alternateName"] = self.alternate_name
         if self.is_live_dataset is not None:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -268,7 +268,8 @@ class MetadataGenerator:
             is_accessible_for_free: Whether the data can be had without payment
                 or an access agreement. Tri-state: None leaves the key absent.
             included_in_data_catalog: URL of a catalog entry that lists this
-                dataset (schema.org/includedInDataCatalog).
+                dataset. Emitted as a ``sc:DataCatalog`` node carrying the
+                URL, the one range schema.org/includedInDataCatalog has.
             profiles: Additional profiles the document declares in
                 ``conformsTo`` alongside Croissant 1.1, by the names in
                 ``PROFILE_CONFORMS_TO``. A list, or one name as a bare
@@ -633,7 +634,14 @@ class MetadataGenerator:
         if self.is_accessible_for_free is not None:
             result["isAccessibleForFree"] = self.is_accessible_for_free
         if self.included_in_data_catalog is not None:
-            result["includedInDataCatalog"] = self.included_in_data_catalog
+            # schema.org gives includedInDataCatalog exactly one range,
+            # DataCatalog. A bare string would be read as a literal under
+            # @vocab, so the URL rides on a node — the shape publisher
+            # already uses for its Organization.
+            result["includedInDataCatalog"] = {
+                "@type": "sc:DataCatalog",
+                "url": self.included_in_data_catalog,
+            }
         if self.field_mappings:
             _apply_field_mappings(result, self.field_mappings)
         return result

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -54,6 +54,30 @@ _CARRIED_BY_ANOTHER = (Outcome.UNCLAIMED, Outcome.FAILED)
 # https://docs.mlcommons.org/croissant/docs/croissant-spec-1.1.html
 CROISSANT_CONFORMS_TO = "http://mlcommons.org/croissant/1.1"
 RAI_CONFORMS_TO = "http://mlcommons.org/croissant/RAI/1.0"
+BIOSCHEMAS_CONFORMS_TO = "https://bioschemas.org/profiles/Dataset/1.0-RELEASE"
+
+# Profiles a document can additionally declare, by the name --profile takes.
+# A new profile is one entry here: the CLI validates against these keys and
+# the generator appends the URI. Nothing else in the document changes, so
+# declaring a profile is a claim about the vocabulary, not a validation of it.
+PROFILE_CONFORMS_TO = {
+    "bioschemas": BIOSCHEMAS_CONFORMS_TO,
+}
+
+
+def _append_conforms_to(metadata_dict: dict, uri: str) -> None:
+    """Declare ``uri`` in conformsTo, which may be absent, a string, or a list."""
+    conforms_to = metadata_dict.get("conformsTo")
+    if conforms_to is None:
+        metadata_dict["conformsTo"] = [uri]
+        return
+    if isinstance(conforms_to, str):
+        metadata_dict["conformsTo"] = (
+            [conforms_to] if conforms_to == uri else [conforms_to, uri]
+        )
+        return
+    if isinstance(conforms_to, list) and uri not in conforms_to:
+        conforms_to.append(uri)
 
 
 def _apply_field_mappings(
@@ -166,6 +190,11 @@ class MetadataGenerator:
         is_live_dataset: Optional[bool] = None,
         temporal_coverage: Optional[str] = None,
         usage_info: Optional[str] = None,
+        identifier: Optional[List[str]] = None,
+        conditions_of_access: Optional[str] = None,
+        is_accessible_for_free: Optional[bool] = None,
+        included_in_data_catalog: Optional[str] = None,
+        profiles: Optional[List[str]] = None,
         field_mappings: Optional[Dict[str, Dict[str, object]]] = None,
         count_csv_rows: bool = False,
         max_workers: Optional[int] = None,
@@ -206,6 +235,19 @@ class MetadataGenerator:
                 free text or ISO 8601 (e.g., "2008/2019", "2023-01-15").
             usage_info: URL of a usage/consent policy (e.g., a DUO term URL,
                 ODRL Offer URL).
+            identifier: Accessions or persistent identifiers the dataset is
+                known by (e.g. a dbGaP phs number, an EGA study accession, a
+                DOI). A single value is emitted as a string, several as a list.
+            conditions_of_access: How access is obtained, in free text (e.g.
+                the data access agreement and committee for a controlled
+                release). schema.org/conditionsOfAccess.
+            is_accessible_for_free: Whether the data can be had without payment
+                or an access agreement. Tri-state: None leaves the key absent.
+            included_in_data_catalog: URL of a catalog entry that lists this
+                dataset (schema.org/includedInDataCatalog).
+            profiles: Additional profiles the document declares in
+                ``conformsTo``, by the names in ``PROFILE_CONFORMS_TO``.
+                Declaring a profile does not validate against it.
             field_mappings: Per-column overrides keyed by field name. Each value
                 is a dict with optional ``equivalent_property`` (vocab URI) and
                 ``data_types`` (list of vocab URIs). Used to link columns to
@@ -227,7 +269,8 @@ class MetadataGenerator:
                 or with a handler the baker does not ship.
 
         Raises:
-            ValueError: If dataset_path is not a directory.
+            ValueError: If dataset_path is not a directory, or a named profile
+                is not one of ``PROFILE_CONFORMS_TO``.
         """
         self.dataset_path = Path(dataset_path).resolve()
         if not self.dataset_path.is_dir():
@@ -253,6 +296,17 @@ class MetadataGenerator:
         self.is_live_dataset = is_live_dataset
         self.temporal_coverage = temporal_coverage
         self.usage_info = usage_info
+        self.identifier = identifier
+        self.conditions_of_access = conditions_of_access
+        self.is_accessible_for_free = is_accessible_for_free
+        self.included_in_data_catalog = included_in_data_catalog
+        unknown = sorted(set(profiles or []) - set(PROFILE_CONFORMS_TO))
+        if unknown:
+            raise ValueError(
+                f"Unknown profile(s) {', '.join(unknown)}; "
+                f"known profiles: {', '.join(sorted(PROFILE_CONFORMS_TO))}"
+            )
+        self.profiles = profiles
         self.field_mappings = field_mappings or {}
         self.includes = includes
         self.excludes = excludes
@@ -548,6 +602,20 @@ class MetadataGenerator:
             result["temporalCoverage"] = self.temporal_coverage
         if self.usage_info is not None:
             result["usageInfo"] = self.usage_info
+        if self.identifier:
+            # One accession reads as a string, the way mlcroissant flattens its
+            # own single-element lists; several stay a list.
+            result["identifier"] = (
+                self.identifier[0] if len(self.identifier) == 1 else self.identifier
+            )
+        if self.conditions_of_access is not None:
+            result["conditionsOfAccess"] = self.conditions_of_access
+        if self.is_accessible_for_free is not None:
+            result["isAccessibleForFree"] = self.is_accessible_for_free
+        if self.included_in_data_catalog is not None:
+            result["includedInDataCatalog"] = self.included_in_data_catalog
+        for profile in self.profiles or []:
+            _append_conforms_to(result, PROFILE_CONFORMS_TO[profile])
         if self.field_mappings:
             _apply_field_mappings(result, self.field_mappings)
         return result

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -613,6 +613,12 @@ class MetadataGenerator:
         # but mlc emits it as ``cr:sdVersion`` (no @context alias); the
         # canonical 1.1 examples use the unprefixed form, so we write the
         # canonical key directly.
+        # mlcroissant takes an ``id`` for the Metadata node but writes no
+        # top-level @id, leaving the Dataset a blank node that nothing can
+        # refer to. The dataset URL is the identifier a reader already has,
+        # and it is what Bioschemas expects there.
+        if self.url:
+            result["@id"] = self.url
         if self.sd_version is not None:
             result["sdVersion"] = self.sd_version
         if self.alternate_name is not None:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -66,6 +66,44 @@ PROFILE_CONFORMS_TO = {
 }
 
 
+def normalize_profiles(
+    profiles: Union[str, List[str], None],
+) -> Optional[List[str]]:
+    """The profile names to declare, cleaned and checked, or None.
+
+    The single owner of the rule: the generator calls it from ``__init__`` and
+    the CLI calls it from the ``--profile`` callback, so a library caller and a
+    command line get the same contract and the same message. Strips each name,
+    drops empties, splits comma lists the way ``--keywords`` and
+    ``--identifier`` take them, and deduplicates with ``dict.fromkeys`` so a
+    name given twice is declared once in the order it was first asked for.
+
+    A bare string is one flag's worth of input rather than an iterable of
+    characters, so ``profiles="bioschemas"`` means what it reads as.
+
+    Raises:
+        ValueError: If a name has no conformsTo URI in ``PROFILE_CONFORMS_TO``.
+    """
+    if profiles is None:
+        return None
+    if isinstance(profiles, str):
+        profiles = [profiles]
+    names = [
+        stripped
+        for value in profiles
+        for part in value.split(",")
+        if (stripped := part.strip())
+    ]
+    names = list(dict.fromkeys(names))
+    unknown = [name for name in names if name not in PROFILE_CONFORMS_TO]
+    if unknown:
+        raise ValueError(
+            f"Unknown profile(s): {', '.join(repr(name) for name in unknown)}. "
+            f"Known profiles: {', '.join(sorted(PROFILE_CONFORMS_TO))}"
+        )
+    return names or None
+
+
 def _apply_field_mappings(
     metadata_dict: dict, mappings: Dict[str, Dict[str, object]]
 ) -> None:
@@ -180,7 +218,7 @@ class MetadataGenerator:
         conditions_of_access: Optional[str] = None,
         is_accessible_for_free: Optional[bool] = None,
         included_in_data_catalog: Optional[str] = None,
-        profiles: Optional[List[str]] = None,
+        profiles: Union[str, List[str], None] = None,
         field_mappings: Optional[Dict[str, Dict[str, object]]] = None,
         count_csv_rows: bool = False,
         max_workers: Optional[int] = None,
@@ -233,8 +271,9 @@ class MetadataGenerator:
                 dataset (schema.org/includedInDataCatalog).
             profiles: Additional profiles the document declares in
                 ``conformsTo`` alongside Croissant 1.1, by the names in
-                ``PROFILE_CONFORMS_TO``. Declaring a profile does not
-                validate against it.
+                ``PROFILE_CONFORMS_TO``. A list, or one name as a bare
+                string; either form may carry comma-separated names.
+                Normalised by ``normalize_profiles`` at construction.
             field_mappings: Per-column overrides keyed by field name. Each value
                 is a dict with optional ``equivalent_property`` (vocab URI) and
                 ``data_types`` (list of vocab URIs). Used to link columns to
@@ -287,13 +326,7 @@ class MetadataGenerator:
         self.conditions_of_access = conditions_of_access
         self.is_accessible_for_free = is_accessible_for_free
         self.included_in_data_catalog = included_in_data_catalog
-        unknown = sorted(set(profiles or []) - set(PROFILE_CONFORMS_TO))
-        if unknown:
-            raise ValueError(
-                f"Unknown profile(s) {', '.join(unknown)}; "
-                f"known profiles: {', '.join(sorted(PROFILE_CONFORMS_TO))}"
-            )
-        self.profiles = profiles
+        self.profiles = normalize_profiles(profiles)
         self.field_mappings = field_mappings or {}
         self.includes = includes
         self.excludes = excludes
@@ -905,4 +938,4 @@ class MetadataGenerator:
             f.write("\n")
 
 
-__all__ = ["MetadataGenerator", "serialize_datetime"]
+__all__ = ["MetadataGenerator", "normalize_profiles", "serialize_datetime"]

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import mlcroissant as mlc
 
@@ -58,26 +58,12 @@ BIOSCHEMAS_CONFORMS_TO = "https://bioschemas.org/profiles/Dataset/1.0-RELEASE"
 
 # Profiles a document can additionally declare, by the name --profile takes.
 # A new profile is one entry here: the CLI validates against these keys and
-# the generator appends the URI. Nothing else in the document changes, so
-# declaring a profile is a claim about the vocabulary, not a validation of it.
+# the generator declares the URI alongside CROISSANT_CONFORMS_TO. Nothing else
+# in the document changes, so declaring a profile is a claim about the
+# vocabulary, not a validation against it.
 PROFILE_CONFORMS_TO = {
     "bioschemas": BIOSCHEMAS_CONFORMS_TO,
 }
-
-
-def _append_conforms_to(metadata_dict: dict, uri: str) -> None:
-    """Declare ``uri`` in conformsTo, which may be absent, a string, or a list."""
-    conforms_to = metadata_dict.get("conformsTo")
-    if conforms_to is None:
-        metadata_dict["conformsTo"] = [uri]
-        return
-    if isinstance(conforms_to, str):
-        metadata_dict["conformsTo"] = (
-            [conforms_to] if conforms_to == uri else [conforms_to, uri]
-        )
-        return
-    if isinstance(conforms_to, list) and uri not in conforms_to:
-        conforms_to.append(uri)
 
 
 def _apply_field_mappings(
@@ -246,8 +232,9 @@ class MetadataGenerator:
             included_in_data_catalog: URL of a catalog entry that lists this
                 dataset (schema.org/includedInDataCatalog).
             profiles: Additional profiles the document declares in
-                ``conformsTo``, by the names in ``PROFILE_CONFORMS_TO``.
-                Declaring a profile does not validate against it.
+                ``conformsTo`` alongside Croissant 1.1, by the names in
+                ``PROFILE_CONFORMS_TO``. Declaring a profile does not
+                validate against it.
             field_mappings: Per-column overrides keyed by field name. Each value
                 is a dict with optional ``equivalent_property`` (vocab URI) and
                 ``data_types`` (list of vocab URIs). Used to link columns to
@@ -570,7 +557,7 @@ class MetadataGenerator:
             date_modified=self._parse_iso(self.date_modified),
             version=self.version or "1.0.0",
             cite_as=self._build_citation(),
-            conforms_to=CROISSANT_CONFORMS_TO,
+            conforms_to=self._resolve_conforms_to(),
             keywords=self.keywords,
             in_language=self.in_language,
             same_as=self.same_as,
@@ -614,8 +601,6 @@ class MetadataGenerator:
             result["isAccessibleForFree"] = self.is_accessible_for_free
         if self.included_in_data_catalog is not None:
             result["includedInDataCatalog"] = self.included_in_data_catalog
-        for profile in self.profiles or []:
-            _append_conforms_to(result, PROFILE_CONFORMS_TO[profile])
         if self.field_mappings:
             _apply_field_mappings(result, self.field_mappings)
         return result
@@ -759,6 +744,20 @@ class MetadataGenerator:
             f"Dataset containing {len(file_metadata)} files "
             f"({', '.join(sorted(file_types))}) with automatically inferred types and structure"
         )
+
+    def _resolve_conforms_to(self) -> Union[str, List[str]]:
+        """Croissant 1.1, plus any profile the caller asked to declare.
+
+        A bare string when there is nothing to add, because that is what the
+        canonical 1.1 examples carry. ``dict.fromkeys`` keeps the declared
+        order while dropping a profile named twice.
+        """
+        if not self.profiles:
+            return CROISSANT_CONFORMS_TO
+        profile_uris = dict.fromkeys(
+            PROFILE_CONFORMS_TO[profile] for profile in self.profiles
+        )
+        return [CROISSANT_CONFORMS_TO, *profile_uris]
 
     def _resolve_license(self) -> str:
         if not self.license:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -68,13 +68,31 @@ PROFILE_CONFORMS_TO = {
 # names a profile and then omits what the profile lists as minimum scores
 # worse than one that declares nothing. The generator refuses instead.
 #
-# Bioschemas Dataset 1.0-RELEASE lists ten minimum fields. The five here are
-# the ones a bake can lack; @context, @type and name are always written, @id
-# follows from url, and dct:conformsTo is what the declaration itself adds.
+# The list mirrors the profile's own minimums rather than what a bake happens
+# to be able to omit. Bioschemas Dataset 1.0-RELEASE lists ten; @context,
+# @type and name are always written and dct:conformsTo is what the declaration
+# itself adds, so the six below are what is left. description and license are
+# defaulted today and so can never be reported missing; they stay listed so the
+# check follows the profile rather than the defaults.
 # https://bioschemas.org/profiles/Dataset/1.0-RELEASE
 PROFILE_MINIMUM_KEYS = {
-    "bioschemas": ("description", "identifier", "keywords", "license", "url"),
+    "bioschemas": ("@id", "description", "identifier", "keywords", "license", "url"),
 }
+
+
+def url_is_iri_safe(url: Optional[str]) -> bool:
+    """Whether ``url`` can stand as the document's ``@id``.
+
+    An ``@id`` is an IRI, and an IRI carries no whitespace: a url with a
+    space in it makes the whole document unreadable to a JSON-LD parser, so
+    emitting one costs more than leaving the dataset unnamed. Only whitespace
+    is checked, because that is the one thing that breaks parsing outright,
+    and ``url`` itself is written as given whatever this returns.
+
+    One owner for the rule: the generator asks before injecting the key, and
+    the CLI asks before telling the user why it is missing.
+    """
+    return bool(url) and not any(character.isspace() for character in url)
 
 
 def normalize_profiles(
@@ -638,8 +656,10 @@ class MetadataGenerator:
         # mlcroissant takes an ``id`` for the Metadata node but writes no
         # top-level @id, leaving the Dataset a blank node that nothing can
         # refer to. The dataset URL is the identifier a reader already has,
-        # and it is what Bioschemas expects there.
-        if self.url:
+        # and it is what Bioschemas expects there. A url no IRI can be built
+        # from is skipped rather than written: the CLI says so on stderr, and
+        # a declared profile that requires @id refuses the bake outright.
+        if url_is_iri_safe(self.url):
             result["@id"] = self.url
         if self.alternate_name is not None:
             result["alternateName"] = self.alternate_name
@@ -1002,4 +1022,9 @@ class MetadataGenerator:
             f.write("\n")
 
 
-__all__ = ["MetadataGenerator", "normalize_profiles", "serialize_datetime"]
+__all__ = [
+    "MetadataGenerator",
+    "normalize_profiles",
+    "serialize_datetime",
+    "url_is_iri_safe",
+]

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -272,7 +272,8 @@ class MetadataGenerator:
                 ODRL Offer URL).
             identifier: Accessions or persistent identifiers the dataset is
                 known by (e.g. a dbGaP phs number, an EGA study accession, a
-                DOI). A single value is emitted as a string, several as a list.
+                DOI). Deduplicated in the order given; one value is emitted
+                as a string, several as a list.
             conditions_of_access: How access is obtained, in free text (e.g.
                 the data access agreement and committee for a controlled
                 release). schema.org/conditionsOfAccess.
@@ -650,10 +651,11 @@ class MetadataGenerator:
             result["usageInfo"] = self.usage_info
         if self.identifier:
             # One accession reads as a string, the way mlcroissant flattens its
-            # own single-element lists; several stay a list.
-            result["identifier"] = (
-                self.identifier[0] if len(self.identifier) == 1 else self.identifier
-            )
+            # own single-element lists; several stay a list. Deduplicated in
+            # declared order first, so naming an accession twice does not turn
+            # the same claim into a list of two.
+            accessions = list(dict.fromkeys(self.identifier))
+            result["identifier"] = accessions[0] if len(accessions) == 1 else accessions
         if self.conditions_of_access is not None:
             result["conditionsOfAccess"] = self.conditions_of_access
         if self.is_accessible_for_free is not None:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -80,19 +80,20 @@ PROFILE_MINIMUM_KEYS = {
 }
 
 
-def url_is_iri_safe(url: Optional[str]) -> bool:
-    """Whether ``url`` can stand as the document's ``@id``.
+def url_has_whitespace(url: str) -> bool:
+    """Whether ``url`` carries whitespace, which no IRI may.
 
-    An ``@id`` is an IRI, and an IRI carries no whitespace: a url with a
-    space in it makes the whole document unreadable to a JSON-LD parser, so
-    emitting one costs more than leaving the dataset unnamed. Only whitespace
-    is checked, because that is the one thing that breaks parsing outright,
-    and ``url`` itself is written as given whatever this returns.
+    The document's ``@id`` is an IRI: a url with a space in it makes the whole
+    document unreadable to a JSON-LD parser, so a url like that is left out of
+    the ``@id`` rather than written into it. Whitespace is all this asks
+    about, because it is the one thing that breaks parsing outright, and
+    ``url`` itself is written as given whatever the answer is.
 
     One owner for the rule: the generator asks before injecting the key, and
-    the CLI asks before telling the user why it is missing.
+    the CLI asks before telling the user why the key is missing. Both ask only
+    when there is a url to ask about.
     """
-    return bool(url) and not any(character.isspace() for character in url)
+    return any(character.isspace() for character in url)
 
 
 def normalize_profiles(
@@ -657,17 +658,25 @@ class MetadataGenerator:
         # top-level @id, leaving the Dataset a blank node that nothing can
         # refer to. The dataset URL is the identifier a reader already has,
         # and it is what Bioschemas expects there. A url no IRI can be built
-        # from is skipped rather than written: the CLI says so on stderr, and
-        # a declared profile that requires @id refuses the bake outright.
+        # from is skipped rather than written: a declared profile that
+        # requires @id refuses the bake outright, and the CLI repeats the
+        # warning below on stderr, where a terminal user will see it.
         # Written beside the other node keywords, where a reader looks for the
         # subject of the graph, rather than trailing the record sets.
-        if url_is_iri_safe(self.url):
+        if self.url and not url_has_whitespace(self.url):
             result = {
                 "@context": result.pop("@context"),
                 "@type": result.pop("@type"),
                 "@id": self.url,
                 **result,
             }
+        elif self.url:
+            logger.warning(
+                "url %r contains whitespace, so no @id was emitted for the "
+                "dataset. Percent-encode the whitespace (a space becomes "
+                "%%20) to give the document an identifier.",
+                self.url,
+            )
         if self.alternate_name is not None:
             result["alternateName"] = self.alternate_name
         if self.is_live_dataset is not None:
@@ -707,8 +716,8 @@ class MetadataGenerator:
         Read off the assembled document rather than the constructor
         arguments, because what reaches the file is not always what was
         passed: ``description`` is generated when none was given, ``license``
-        is defaulted, and ``@id`` is injected from ``url``. The check has to
-        agree with what a validator will read.
+        is defaulted, and ``@id`` is injected from ``url`` when the url can be
+        an IRI. The check has to agree with what a validator will read.
 
         Raises:
             ValueError: naming every missing field, so one run tells the
@@ -1033,5 +1042,5 @@ __all__ = [
     "MetadataGenerator",
     "normalize_profiles",
     "serialize_datetime",
-    "url_is_iri_safe",
+    "url_has_whitespace",
 ]

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -633,14 +633,14 @@ class MetadataGenerator:
         # but mlc emits it as ``cr:sdVersion`` (no @context alias); the
         # canonical 1.1 examples use the unprefixed form, so we write the
         # canonical key directly.
+        if self.sd_version is not None:
+            result["sdVersion"] = self.sd_version
         # mlcroissant takes an ``id`` for the Metadata node but writes no
         # top-level @id, leaving the Dataset a blank node that nothing can
         # refer to. The dataset URL is the identifier a reader already has,
         # and it is what Bioschemas expects there.
         if self.url:
             result["@id"] = self.url
-        if self.sd_version is not None:
-            result["sdVersion"] = self.sd_version
         if self.alternate_name is not None:
             result["alternateName"] = self.alternate_name
         if self.is_live_dataset is not None:
@@ -663,7 +663,7 @@ class MetadataGenerator:
         if self.included_in_data_catalog is not None:
             # schema.org gives includedInDataCatalog exactly one range,
             # DataCatalog. A bare string would be read as a literal under
-            # @vocab, so the URL rides on a node — the shape publisher
+            # @vocab, so the URL rides on a node, the shape publisher
             # already uses for its Organization.
             result["includedInDataCatalog"] = {
                 "@type": "sc:DataCatalog",

--- a/tests/data/output/eicu_demo_croissant.jsonld
+++ b/tests/data/output/eicu_demo_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/eicu-crd-demo/2.0.1/",
   "name": "eICU Collaborative Research Database Demo",
   "description": "Demo version of the eICU Collaborative Research Database",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -6561,6 +6562,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/eicu-crd-demo/2.0.1/"
+  ]
 }

--- a/tests/data/output/eicu_demo_croissant.jsonld
+++ b/tests/data/output/eicu_demo_croissant.jsonld
@@ -6561,5 +6561,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/eicu-crd-demo/2.0.1/"
 }

--- a/tests/data/output/geo_soft_croissant.jsonld
+++ b/tests/data/output/geo_soft_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://www.ncbi.nlm.nih.gov/geo/",
   "name": "GEO SOFT family exports (demo)",
   "description": "Three NCBI GEO family exports: two modern tableless deposits and one classic series with data tables",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -3531,6 +3532,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://www.ncbi.nlm.nih.gov/geo/"
+  ]
 }

--- a/tests/data/output/geo_soft_croissant.jsonld
+++ b/tests/data/output/geo_soft_croissant.jsonld
@@ -3531,5 +3531,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://www.ncbi.nlm.nih.gov/geo/"
 }

--- a/tests/data/output/gharchive_demo_croissant.jsonld
+++ b/tests/data/output/gharchive_demo_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://www.gharchive.org/",
   "name": "GH Archive (demo slice)",
   "description": "200-event slice of GitHub Archive hourly JSONL export (2023-01-01 00:00 UTC)",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -10411,6 +10412,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://www.gharchive.org/"
+  ]
 }

--- a/tests/data/output/gharchive_demo_croissant.jsonld
+++ b/tests/data/output/gharchive_demo_croissant.jsonld
@@ -10411,5 +10411,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://www.gharchive.org/"
 }

--- a/tests/data/output/glaucoma_fundus_croissant.jsonld
+++ b/tests/data/output/glaucoma_fundus_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/hyg-dataset/1.0.0/",
   "name": "Hillel Yaffe Glaucoma Dataset (subset)",
   "description": "Subset of fundus images for glaucoma screening with GON labels",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -281,6 +282,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/hyg-dataset/1.0.0/"
+  ]
 }

--- a/tests/data/output/glaucoma_fundus_croissant.jsonld
+++ b/tests/data/output/glaucoma_fundus_croissant.jsonld
@@ -281,5 +281,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/hyg-dataset/1.0.0/"
 }

--- a/tests/data/output/meds_full_croissant.jsonld
+++ b/tests/data/output/meds_full_croissant.jsonld
@@ -46,6 +46,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimic-iv-meds/",
   "name": "MIMIC-IV in MEDS format (full)",
   "description": "MIMIC-IV converted to Medical Event Data Standard (MEDS) format",
   "conformsTo": "http://mlcommons.org/croissant/1.1",

--- a/tests/data/output/mimiciv_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant.jsonld
@@ -5875,5 +5875,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/mimic-iv-demo/"
 }

--- a/tests/data/output/mimiciv_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimic-iv-demo/",
   "name": "MIMIC-IV Demo Dataset",
   "description": "Demo subset of MIMIC-IV, a freely accessible electronic health record dataset from Beth Israel Deaconess Medical Center (2008-2019)",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -5875,6 +5876,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/mimic-iv-demo/"
+  ]
 }

--- a/tests/data/output/mimiciv_demo_croissant_rai.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant_rai.jsonld
@@ -48,6 +48,7 @@
     "prov": "http://www.w3.org/ns/prov#"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimic-iv-demo/",
   "name": "MIMIC-IV Demo Dataset",
   "description": "Demo subset of MIMIC-IV, a freely accessible electronic health record dataset from Beth Israel Deaconess Medical Center (2008-2019)",
   "conformsTo": "http://mlcommons.org/croissant/1.1",

--- a/tests/data/output/mimiciv_demo_meds_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_meds_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimic-iv-demo-meds/0.0.1/",
   "name": "MIMIC-IV demo data in the Medical Event Data Standard (MEDS)",
   "description": "MEDS demo of MIMIC-IV represented as Parquet event streams",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -1244,6 +1245,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/mimic-iv-demo-meds/0.0.1/"
+  ]
 }

--- a/tests/data/output/mimiciv_demo_meds_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_meds_croissant.jsonld
@@ -1244,5 +1244,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/mimic-iv-demo-meds/0.0.1/"
 }

--- a/tests/data/output/mimiciv_demo_omop_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_omop_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimic-iv-demo-omop/0.9/",
   "name": "MIMIC-IV demo data in the OMOP Common Data Model",
   "description": "A 100-patient demo of MIMIC-IV in the OMOP Common Data Model",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -6121,6 +6122,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/mimic-iv-demo-omop/0.9/"
+  ]
 }

--- a/tests/data/output/mimiciv_demo_omop_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_omop_croissant.jsonld
@@ -6121,5 +6121,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/mimic-iv-demo-omop/0.9/"
 }

--- a/tests/data/output/mimiciv_fhir_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_fhir_demo_croissant.jsonld
@@ -12564,5 +12564,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/mimic-iv-fhir-demo/2.1.0/"
 }

--- a/tests/data/output/mimiciv_fhir_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_fhir_demo_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimic-iv-fhir-demo/2.1.0/",
   "name": "MIMIC-IV Clinical Database Demo on FHIR",
   "description": "100-patient demo of MIMIC-IV represented as FHIR R4 NDJSON resources",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -12564,6 +12565,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/mimic-iv-fhir-demo/2.1.0/"
+  ]
 }

--- a/tests/data/output/mimiciv_full_croissant.jsonld
+++ b/tests/data/output/mimiciv_full_croissant.jsonld
@@ -46,6 +46,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mimiciv/",
   "name": "MIMIC-IV (full)",
   "description": "MIMIC-IV hospital and ICU module data",
   "conformsTo": "http://mlcommons.org/croissant/1.1",

--- a/tests/data/output/mitdb_wfdb_croissant.jsonld
+++ b/tests/data/output/mitdb_wfdb_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/mitdb/1.0.0/",
   "name": "MIT-BIH Arrhythmia Database",
   "description": "MIT-BIH Arrhythmia Database containing 48 ECG recordings with annotations",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -4251,6 +4252,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/mitdb/1.0.0/"
+  ]
 }

--- a/tests/data/output/mitdb_wfdb_croissant.jsonld
+++ b/tests/data/output/mitdb_wfdb_croissant.jsonld
@@ -4251,5 +4251,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/mitdb/1.0.0/"
 }

--- a/tests/data/output/open_targets_like_croissant.jsonld
+++ b/tests/data/output/open_targets_like_croissant.jsonld
@@ -643,5 +643,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://platform.opentargets.org"
 }

--- a/tests/data/output/open_targets_like_croissant.jsonld
+++ b/tests/data/output/open_targets_like_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://platform.opentargets.org",
   "name": "Open Targets Platform (toy)",
   "description": "Synthetic subset of Open Targets Platform data for testing partitioned Parquet support",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -643,6 +644,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://platform.opentargets.org"
+  ]
 }

--- a/tests/data/output/open_targets_subset_croissant.jsonld
+++ b/tests/data/output/open_targets_subset_croissant.jsonld
@@ -454,5 +454,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://platform.opentargets.org"
 }

--- a/tests/data/output/open_targets_subset_croissant.jsonld
+++ b/tests/data/output/open_targets_subset_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://platform.opentargets.org",
   "name": "Open Targets Platform (subset)",
   "description": "Subset of Open Targets Platform for testing",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -454,6 +455,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://platform.opentargets.org"
+  ]
 }

--- a/tests/data/output/reserved_names_croissant.jsonld
+++ b/tests/data/output/reserved_names_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://example.com/reserved-name-test",
   "name": "Reserved-name regression test",
   "description": "Dataset containing 1 files (application/vnd.apache.parquet) with automatically inferred types and structure",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -185,6 +186,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://example.com/reserved-name-test"
+  ]
 }

--- a/tests/data/output/reserved_names_croissant.jsonld
+++ b/tests/data/output/reserved_names_croissant.jsonld
@@ -185,5 +185,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://example.com/reserved-name-test"
 }

--- a/tests/data/output/satellite_public_health_croissant.jsonld
+++ b/tests/data/output/satellite_public_health_croissant.jsonld
@@ -15458,5 +15458,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/multimodal-satellite-data/1.0.0/"
 }

--- a/tests/data/output/satellite_public_health_croissant.jsonld
+++ b/tests/data/output/satellite_public_health_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/multimodal-satellite-data/1.0.0/",
   "name": "Multi-Modal Satellite Imagery for Public Health (subset)",
   "description": "Subset of Sentinel-2 satellite imagery linked to public health indicators in Colombia",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -15458,6 +15459,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/multimodal-satellite-data/1.0.0/"
+  ]
 }

--- a/tests/data/output/spect_demo_croissant.jsonld
+++ b/tests/data/output/spect_demo_croissant.jsonld
@@ -386,5 +386,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://physionet.org/content/myocardial-perfusion-spect/1.0.0/"
 }

--- a/tests/data/output/spect_demo_croissant.jsonld
+++ b/tests/data/output/spect_demo_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://physionet.org/content/myocardial-perfusion-spect/1.0.0/",
   "name": "Myocardial Perfusion SPECT (demo subset)",
   "description": "Mixed DICOM + NIfTI subset of the PhysioNet open-access SPECT database",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -386,6 +387,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://physionet.org/content/myocardial-perfusion-spect/1.0.0/"
+  ]
 }

--- a/tests/data/output/uniprot_demo_croissant.jsonld
+++ b/tests/data/output/uniprot_demo_croissant.jsonld
@@ -289,5 +289,6 @@
         }
       ]
     }
-  ]
+  ],
+  "@id": "https://www.uniprot.org/uniprotkb?query=reviewed:true&organism_id=9606"
 }

--- a/tests/data/output/uniprot_demo_croissant.jsonld
+++ b/tests/data/output/uniprot_demo_croissant.jsonld
@@ -47,6 +47,7 @@
     "transform": "cr:transform"
   },
   "@type": "sc:Dataset",
+  "@id": "https://www.uniprot.org/uniprotkb?query=reviewed:true&organism_id=9606",
   "name": "UniProt Human Reviewed (demo)",
   "description": "200 reviewed human proteins from UniProt Swiss-Prot",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
@@ -289,6 +290,5 @@
         }
       ]
     }
-  ],
-  "@id": "https://www.uniprot.org/uniprotkb?query=reviewed:true&organism_id=9606"
+  ]
 }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -298,8 +298,14 @@ def bake_with(handlers: Iterable[FileTypeHandler], directory: Path, **kwargs):
 runner = CliRunner()
 
 
-def cli(dataset: Path, output: Path, *extra: str):
-    """Invoke the CLI over ``dataset`` with the minimum viable flag set."""
+def cli(dataset: Path, output: Path, *extra: str, validate: bool = False):
+    """Invoke the CLI over ``dataset`` with the minimum viable flag set.
+
+    Validation is off by default: most callers assert on what was written
+    rather than on mlcroissant reading it back, and it is the slow half of a
+    bake. Pass ``validate=True`` where the default path a user takes is the
+    point of the test.
+    """
     return runner.invoke(
         app,
         [
@@ -309,7 +315,7 @@ def cli(dataset: Path, output: Path, *extra: str):
             str(output),
             "--creator",
             "Tester",
-            "--no-validate",
+            *([] if validate else ["--no-validate"]),
             *extra,
         ],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from croissant_baker.metadata_generator import (
     MetadataGenerator,
     RAI_CONFORMS_TO,
     normalize_profiles,
+    url_is_iri_safe,
 )
 from tests.helpers import cli
 
@@ -1048,6 +1049,78 @@ def test_url_becomes_the_dataset_id(csv_dataset: Path, tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert json.loads(output.read_text())["@id"] == "https://example.org/ds"
+
+
+@pytest.mark.parametrize(
+    "url,usable",
+    [
+        ("https://example.org/ds", True),
+        ("https://example.org/my%20dataset", True),
+        ("https://example.org/my dataset", False),
+        ("https://example.org/my\tdataset", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_url_is_iri_safe_rejects_whitespace(url, usable: bool) -> None:
+    """An @id is an IRI, and an IRI carries no whitespace."""
+    assert url_is_iri_safe(url) is usable
+
+
+def test_url_with_whitespace_still_bakes_without_an_id(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """A url a JSON-LD parser cannot read must not become the document's @id.
+
+    Emitting it anyway made the whole bake fail validation, which is a
+    steeper price than the url was worth.
+    """
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset, output, "--url", "https://example.org/my dataset", validate=True
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "@id" not in json.loads(output.read_text())
+
+
+def test_url_with_whitespace_warns_and_says_how_to_fix_it(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """Dropping the @id silently would leave the user nothing to act on."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--url", "https://example.org/my dataset")
+
+    assert result.exit_code == 0, result.output
+    assert "Warning:" in result.stderr
+    assert "whitespace" in result.stderr
+    assert "%20" in result.stderr
+
+
+def test_bioschemas_refuses_a_url_that_yields_no_id(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """The profile lists @id as a minimum, so a url that cannot be one fails."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset,
+        output,
+        "--identifier",
+        "phs000218.v1.p1",
+        "--keywords",
+        "cardiology",
+        "--url",
+        "https://example.org/my dataset",
+        "--profile",
+        "bioschemas",
+    )
+
+    assert result.exit_code != 0
+    assert "@id" in result.stderr
+    assert "whitespace" in result.stderr
 
 
 def test_no_url_leaves_the_dataset_id_absent(csv_dataset: Path, tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1009,17 +1009,56 @@ def test_is_accessible_for_free_emits_the_boolean_asked_for(
     assert json.loads(output.read_text())["isAccessibleForFree"] is expected
 
 
-def test_included_in_data_catalog_passes_through(
+def test_included_in_data_catalog_emits_a_data_catalog_node(
     csv_dataset: Path, tmp_path: Path
 ) -> None:
-    """--included-in-data-catalog carries the catalog URL through verbatim."""
+    """The URL rides on a DataCatalog node, the only range schema.org gives it.
+
+    A bare string would be read as a literal under @vocab, which is not what
+    the property means.
+    """
     output = tmp_path / "output.jsonld"
     catalog = "https://datacatalog.ccdi.cancer.gov/"
 
     result = cli(csv_dataset, output, "--included-in-data-catalog", catalog)
 
     assert result.exit_code == 0, result.output
-    assert json.loads(output.read_text())["includedInDataCatalog"] == catalog
+    assert json.loads(output.read_text())["includedInDataCatalog"] == {
+        "@type": "sc:DataCatalog",
+        "url": catalog,
+    }
+
+
+def test_included_in_data_catalog_rejects_free_text(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """The help text says URL, so free text is refused rather than emitted."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--included-in-data-catalog", "the CCDI catalog")
+
+    assert result.exit_code != 0
+    assert "Unexpected error" not in result.output
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+@pytest.mark.parametrize(
+    "flag,key",
+    [
+        ("--conditions-of-access", "conditionsOfAccess"),
+        ("--included-in-data-catalog", "includedInDataCatalog"),
+    ],
+)
+def test_blank_text_flags_leave_their_key_absent(
+    csv_dataset: Path, tmp_path: Path, flag: str, key: str, blank: str
+) -> None:
+    """An empty property says less than no property; both are stripped away."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, flag, blank)
+
+    assert result.exit_code == 0, result.output
+    assert key not in json.loads(output.read_text())
 
 
 def test_profile_bioschemas_appends_to_conforms_to(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,11 +13,25 @@ from croissant_baker.metadata_generator import (
     BIOSCHEMAS_CONFORMS_TO,
     CROISSANT_CONFORMS_TO,
     MetadataGenerator,
+    RAI_CONFORMS_TO,
     normalize_profiles,
 )
 from tests.helpers import cli
 
 runner = CliRunner()
+
+#: The flags a document needs before it may declare --profile bioschemas.
+#: The profile's other minimum fields are covered without asking: name comes
+#: from the directory, description and license are defaulted, and @id follows
+#: from url.
+BIOSCHEMAS_MINIMUMS = (
+    "--identifier",
+    "phs000218.v1.p1",
+    "--keywords",
+    "cardiology,icu",
+    "--url",
+    "https://example.org/ds",
+)
 
 
 @pytest.fixture
@@ -1101,12 +1115,12 @@ def test_profile_bioschemas_appends_to_conforms_to(
     """--profile bioschemas declares the second profile alongside Croissant 1.1."""
     output = tmp_path / "output.jsonld"
 
-    result = cli(csv_dataset, output, "--profile", "bioschemas")
+    result = cli(csv_dataset, output, *BIOSCHEMAS_MINIMUMS, "--profile", "bioschemas")
 
     assert result.exit_code == 0, result.output
     assert json.loads(output.read_text())["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.1",
-        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+        CROISSANT_CONFORMS_TO,
+        BIOSCHEMAS_CONFORMS_TO,
     ]
 
 
@@ -1115,13 +1129,19 @@ def test_repeated_profile_is_declared_once(csv_dataset: Path, tmp_path: Path) ->
     output = tmp_path / "output.jsonld"
 
     result = cli(
-        csv_dataset, output, "--profile", "bioschemas", "--profile", "bioschemas"
+        csv_dataset,
+        output,
+        *BIOSCHEMAS_MINIMUMS,
+        "--profile",
+        "bioschemas",
+        "--profile",
+        "bioschemas",
     )
 
     assert result.exit_code == 0, result.output
     assert json.loads(output.read_text())["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.1",
-        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+        CROISSANT_CONFORMS_TO,
+        BIOSCHEMAS_CONFORMS_TO,
     ]
 
 
@@ -1134,6 +1154,7 @@ def test_profile_coexists_with_rai_conformance(
     result = cli(
         csv_dataset,
         output,
+        *BIOSCHEMAS_MINIMUMS,
         "--profile",
         "bioschemas",
         "--rai-data-collection",
@@ -1142,10 +1163,63 @@ def test_profile_coexists_with_rai_conformance(
 
     assert result.exit_code == 0, result.output
     assert json.loads(output.read_text())["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.1",
-        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
-        "http://mlcommons.org/croissant/RAI/1.0",
+        CROISSANT_CONFORMS_TO,
+        BIOSCHEMAS_CONFORMS_TO,
+        RAI_CONFORMS_TO,
     ]
+
+
+def test_bioschemas_profile_refuses_a_document_missing_its_minimums(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """Declaring a profile the document fails is worse than declaring none.
+
+    A SHACL validator reads conformsTo and checks what the profile requires,
+    so an undeclared document scores better than one that claims Bioschemas
+    and then omits the fields it lists as minimum.
+    """
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--profile", "bioschemas")
+
+    assert result.exit_code != 0
+    assert "Unexpected error" not in result.output
+    for field in ("identifier", "keywords", "url"):
+        assert field in result.output
+    assert not output.exists()
+
+
+def test_bioschemas_refusal_names_only_what_is_missing(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """The user is told which fields to supply, not the whole minimum set."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset,
+        output,
+        "--url",
+        "https://example.org/ds",
+        "--keywords",
+        "cardiology",
+        "--profile",
+        "bioschemas",
+    )
+
+    assert result.exit_code != 0
+    assert "identifier" in result.output
+    assert "keywords" not in result.output
+
+
+def test_bioschemas_minimums_are_checked_by_the_generator(tmp_path: Path) -> None:
+    """A library caller gets the same refusal, from the same owner."""
+    dataset = tmp_path / "ds"
+    dataset.mkdir()
+    (dataset / "data.csv").write_text("id,name\n1,Ada\n")
+    generator = MetadataGenerator(dataset_path=str(dataset), profiles=["bioschemas"])
+
+    with pytest.raises(ValueError, match="identifier"):
+        generator.generate_metadata()
 
 
 def test_unknown_profile_is_rejected(csv_dataset: Path, tmp_path: Path) -> None:
@@ -1182,7 +1256,9 @@ def test_comma_delimited_profiles_are_accepted(
     """--profile takes a comma list, as --identifier and --keywords already do."""
     output = tmp_path / "output.jsonld"
 
-    result = cli(csv_dataset, output, "--profile", "bioschemas,bioschemas")
+    result = cli(
+        csv_dataset, output, *BIOSCHEMAS_MINIMUMS, "--profile", "bioschemas,bioschemas"
+    )
 
     assert result.exit_code == 0, result.output
     assert json.loads(output.read_text())["conformsTo"] == [
@@ -1241,12 +1317,12 @@ def test_padded_profile_name_is_accepted(csv_dataset: Path, tmp_path: Path) -> N
     """Validation reads the same normalised names the generator is handed."""
     output = tmp_path / "output.jsonld"
 
-    result = cli(csv_dataset, output, "--profile", " bioschemas")
+    result = cli(csv_dataset, output, *BIOSCHEMAS_MINIMUMS, "--profile", " bioschemas ")
 
     assert result.exit_code == 0, result.output
     assert json.loads(output.read_text())["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.1",
-        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+        CROISSANT_CONFORMS_TO,
+        BIOSCHEMAS_CONFORMS_TO,
     ]
 
 
@@ -1282,6 +1358,10 @@ def test_all_discovery_fields_construct_under_mlcroissant(
         output,
         "--identifier",
         "phs000218.v1.p1,EGAS00001000255",
+        "--keywords",
+        "cardiology,icu",
+        "--url",
+        "https://example.org/ds",
         "--conditions-of-access",
         "Controlled access: Data Access Agreement via the DAC",
         "--not-accessible-for-free",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from croissant_baker.metadata_generator import (
     MetadataGenerator,
     RAI_CONFORMS_TO,
     normalize_profiles,
-    url_is_iri_safe,
+    url_has_whitespace,
 )
 from tests.helpers import cli
 
@@ -1064,19 +1064,20 @@ def test_dataset_id_sits_with_the_other_node_keywords(
 
 
 @pytest.mark.parametrize(
-    "url,usable",
+    "url,whitespace",
     [
-        ("https://example.org/ds", True),
-        ("https://example.org/my%20dataset", True),
-        ("https://example.org/my dataset", False),
-        ("https://example.org/my\tdataset", False),
+        ("https://example.org/ds", False),
+        ("https://example.org/my%20dataset", False),
         ("", False),
-        (None, False),
+        ("https://example.org/my dataset", True),
+        ("https://example.org/my\tdataset", True),
     ],
 )
-def test_url_is_iri_safe_rejects_whitespace(url, usable: bool) -> None:
+def test_url_has_whitespace_spots_what_an_iri_cannot_carry(
+    url: str, whitespace: bool
+) -> None:
     """An @id is an IRI, and an IRI carries no whitespace."""
-    assert url_is_iri_safe(url) is usable
+    assert url_has_whitespace(url) is whitespace
 
 
 def test_url_with_whitespace_still_bakes_without_an_id(
@@ -1095,6 +1096,26 @@ def test_url_with_whitespace_still_bakes_without_an_id(
 
     assert result.exit_code == 0, result.output
     assert "@id" not in json.loads(output.read_text())
+
+
+def test_url_with_whitespace_logs_for_a_library_caller(
+    csv_dataset: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The CLI echo reaches nobody who is not at a terminal, so the skip logs.
+
+    The package attaches a NullHandler, so this record goes nowhere unless an
+    application asks for it, which is the point.
+    """
+    generator = MetadataGenerator(
+        dataset_path=str(csv_dataset), url="https://example.org/my dataset"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="croissant_baker.metadata_generator"):
+        document = generator.generate_metadata()
+
+    assert "@id" not in document
+    assert "whitespace" in caplog.text
+    assert "%20" in caplog.text
 
 
 def test_url_with_whitespace_warns_and_says_how_to_fix_it(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1009,6 +1009,40 @@ def test_is_accessible_for_free_emits_the_boolean_asked_for(
     assert json.loads(output.read_text())["isAccessibleForFree"] is expected
 
 
+def test_url_becomes_the_dataset_id(csv_dataset: Path, tmp_path: Path) -> None:
+    """The Dataset node names itself, so a validator has a subject to bind to."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--url", "https://example.org/ds")
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["@id"] == "https://example.org/ds"
+
+
+def test_no_url_leaves_the_dataset_id_absent(csv_dataset: Path, tmp_path: Path) -> None:
+    """There is nothing to name the dataset by, so no @id is invented."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output)
+
+    assert result.exit_code == 0, result.output
+    assert "@id" not in json.loads(output.read_text())
+
+
+def test_dataset_id_reads_back_through_mlcroissant(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """The injected key survives a round trip rather than failing validation."""
+    import mlcroissant as mlc
+
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--url", "https://example.org/ds")
+
+    assert result.exit_code == 0, result.output
+    assert mlc.Dataset(str(output)).metadata.id == "https://example.org/ds"
+
+
 def test_included_in_data_catalog_emits_a_data_catalog_node(
     csv_dataset: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,10 @@ import pytest
 from typer.testing import CliRunner
 
 from croissant_baker.__main__ import app
+from croissant_baker.metadata_generator import (
+    BIOSCHEMAS_CONFORMS_TO,
+    MetadataGenerator,
+)
 from tests.helpers import cli
 
 runner = CliRunner()
@@ -1079,6 +1083,25 @@ def test_unknown_profile_is_rejected(csv_dataset: Path, tmp_path: Path) -> None:
     assert "bioschemas" in result.output
 
 
+def test_unknown_profile_is_rejected_by_the_generator(tmp_path: Path) -> None:
+    """A library caller gets the same refusal at construction, not a KeyError."""
+    with pytest.raises(ValueError, match="bioschemas"):
+        MetadataGenerator(dataset_path=str(tmp_path), profiles=["biocroissant"])
+
+
+def test_padded_profile_name_is_accepted(csv_dataset: Path, tmp_path: Path) -> None:
+    """Validation reads the same normalised names the generator is handed."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--profile", " bioschemas")
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["conformsTo"] == [
+        "http://mlcommons.org/croissant/1.1",
+        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+    ]
+
+
 def test_discovery_keys_absent_without_their_flags(
     csv_dataset: Path, tmp_path: Path
 ) -> None:
@@ -1121,4 +1144,6 @@ def test_all_discovery_fields_construct_under_mlcroissant(
     )
 
     assert result.exit_code == 0, result.output
-    assert mlc.Dataset(str(output)).metadata.name == "test_dataset"
+    metadata = mlc.Dataset(str(output)).metadata
+    assert metadata.name == "test_dataset"
+    assert BIOSCHEMAS_CONFORMS_TO in metadata.conforms_to

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -996,6 +996,23 @@ def test_identifier_repeated_and_comma_delimited_emits_a_list(
     ]
 
 
+def test_repeated_identifier_is_emitted_once(csv_dataset: Path, tmp_path: Path) -> None:
+    """A duplicate must not flip the JSON type from a string to a list."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset,
+        output,
+        "--identifier",
+        "phs000218.v1.p1",
+        "--identifier",
+        "phs000218.v1.p1",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["identifier"] == "phs000218.v1.p1"
+
+
 def test_conditions_of_access_passes_through(csv_dataset: Path, tmp_path: Path) -> None:
     """--conditions-of-access is free text; it reaches the output unchanged."""
     output = tmp_path / "output.jsonld"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from croissant_baker.__main__ import app
 from croissant_baker.metadata_generator import (
     BIOSCHEMAS_CONFORMS_TO,
     MetadataGenerator,
+    normalize_profiles,
 )
 from tests.helpers import cli
 
@@ -1085,8 +1086,37 @@ def test_unknown_profile_is_rejected(csv_dataset: Path, tmp_path: Path) -> None:
 
 def test_unknown_profile_is_rejected_by_the_generator(tmp_path: Path) -> None:
     """A library caller gets the same refusal at construction, not a KeyError."""
-    with pytest.raises(ValueError, match="bioschemas"):
+    with pytest.raises(ValueError, match="biocroissant"):
         MetadataGenerator(dataset_path=str(tmp_path), profiles=["biocroissant"])
+
+
+def test_normalize_profiles_strips_drops_empties_and_dedupes() -> None:
+    """One owner for the rule, so the CLI and a library caller agree."""
+    assert normalize_profiles([" bioschemas ", "", "bioschemas"]) == ["bioschemas"]
+
+
+def test_normalize_profiles_splits_comma_lists() -> None:
+    """--profile takes comma lists, the way --keywords and --identifier do."""
+    assert normalize_profiles(["bioschemas,bioschemas"]) == ["bioschemas"]
+
+
+def test_normalize_profiles_reads_a_bare_string_as_one_name() -> None:
+    """A bare string is one flag's worth of input, not a sequence of letters."""
+    assert normalize_profiles("bioschemas") == ["bioschemas"]
+
+
+def test_normalize_profiles_returns_none_for_nothing() -> None:
+    """Nothing declared leaves conformsTo the bare Croissant string."""
+    assert normalize_profiles(None) is None
+    assert normalize_profiles([]) is None
+    assert normalize_profiles(["  "]) is None
+
+
+def test_generator_stores_the_normalised_profile_names(tmp_path: Path) -> None:
+    """The conformsTo lookup is safe by construction, padding and all."""
+    generator = MetadataGenerator(dataset_path=str(tmp_path), profiles=" bioschemas ")
+
+    assert generator.profiles == ["bioschemas"]
 
 
 def test_padded_profile_name_is_accepted(csv_dataset: Path, tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1348,7 +1348,12 @@ def test_discovery_keys_absent_without_their_flags(
 def test_all_discovery_fields_construct_under_mlcroissant(
     csv_dataset: Path, tmp_path: Path
 ) -> None:
-    """An output carrying all five still loads as a Croissant dataset."""
+    """An output carrying all five still loads as a Croissant dataset.
+
+    The one new-field test that keeps validation on, so the default path
+    every user takes cannot break unnoticed: the rest pass --no-validate
+    to stay fast.
+    """
     import mlcroissant as mlc
 
     output = tmp_path / "output.jsonld"
@@ -1369,9 +1374,16 @@ def test_all_discovery_fields_construct_under_mlcroissant(
         "https://datacatalog.ccdi.cancer.gov/",
         "--profile",
         "bioschemas",
+        validate=True,
     )
 
     assert result.exit_code == 0, result.output
+    # Says the bake took the validating path, so the test cannot quietly stop
+    # covering it.
+    assert "Generated validated Croissant metadata" in result.output
     metadata = mlc.Dataset(str(output)).metadata
     assert metadata.name == "test_dataset"
-    assert BIOSCHEMAS_CONFORMS_TO in metadata.conforms_to
+    assert metadata.conforms_to == [
+        CROISSANT_CONFORMS_TO,
+        BIOSCHEMAS_CONFORMS_TO,
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -536,8 +536,8 @@ def test_native_rai_flags_generate_metadata(csv_dataset: Path, tmp_path: Path) -
     )
     assert metadata["rai:dataUseCases"] == "Benchmarking"
     assert metadata["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.1",
-        "http://mlcommons.org/croissant/RAI/1.0",
+        CROISSANT_CONFORMS_TO,
+        RAI_CONFORMS_TO,
     ]
     assert metadata["rai:dataCollectionTimeFrame"] == [
         "2023-01-01",
@@ -630,8 +630,8 @@ lineage:
 
     metadata = json.loads(output.read_text())
     assert metadata["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.1",
-        "http://mlcommons.org/croissant/RAI/1.0",
+        CROISSANT_CONFORMS_TO,
+        RAI_CONFORMS_TO,
     ]
 
 
@@ -1359,7 +1359,7 @@ def test_discovery_keys_absent_without_their_flags(
         "isAccessibleForFree",
         "includedInDataCatalog",
     } & set(metadata)
-    assert metadata["conformsTo"] == "http://mlcommons.org/croissant/1.1"
+    assert metadata["conformsTo"] == CROISSANT_CONFORMS_TO
 
 
 def test_all_discovery_fields_construct_under_mlcroissant(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1051,6 +1051,18 @@ def test_url_becomes_the_dataset_id(csv_dataset: Path, tmp_path: Path) -> None:
     assert json.loads(output.read_text())["@id"] == "https://example.org/ds"
 
 
+def test_dataset_id_sits_with_the_other_node_keywords(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """A reader looks for the subject at the top, not after the record sets."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--url", "https://example.org/ds")
+
+    assert result.exit_code == 0, result.output
+    assert list(json.loads(output.read_text()))[:3] == ["@context", "@type", "@id"]
+
+
 @pytest.mark.parametrize(
     "url,usable",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 from croissant_baker.__main__ import app
 from croissant_baker.metadata_generator import (
     BIOSCHEMAS_CONFORMS_TO,
+    CROISSANT_CONFORMS_TO,
     MetadataGenerator,
     normalize_profiles,
 )
@@ -1075,13 +1076,57 @@ def test_profile_coexists_with_rai_conformance(
 
 
 def test_unknown_profile_is_rejected(csv_dataset: Path, tmp_path: Path) -> None:
-    """An unrecognised profile name fails loudly and names what is accepted."""
+    """An unrecognised profile name fails loudly and names what was rejected.
+
+    Asserted on the rejected name rather than on ``bioschemas``: the message
+    lists the known profiles too, so ``bioschemas`` would still appear if the
+    name the user typed were dropped from it.
+    """
     output = tmp_path / "output.jsonld"
 
     result = cli(csv_dataset, output, "--profile", "biocroissant")
 
     assert result.exit_code != 0
-    assert "bioschemas" in result.output
+    assert "biocroissant" in result.output
+    assert "Unexpected error" not in result.output
+
+
+def test_unknown_profile_is_rejected_during_parsing(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """--dry-run returns early, so the check has to run while Typer parses."""
+    result = runner.invoke(
+        app, ["--input", str(csv_dataset), "--dry-run", "--profile", "biocroissant"]
+    )
+
+    assert result.exit_code != 0
+    assert "biocroissant" in result.output
+
+
+def test_comma_delimited_profiles_are_accepted(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """--profile takes a comma list, as --identifier and --keywords already do."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--profile", "bioschemas,bioschemas")
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["conformsTo"] == [
+        CROISSANT_CONFORMS_TO,
+        BIOSCHEMAS_CONFORMS_TO,
+    ]
+
+
+def test_bad_usage_info_is_rejected_during_parsing(csv_dataset: Path) -> None:
+    """The URI check runs while parsing, so --dry-run is covered too."""
+    result = runner.invoke(
+        app,
+        ["--input", str(csv_dataset), "--dry-run", "--usage-info", "see license file"],
+    )
+
+    assert result.exit_code != 0
+    assert "Unexpected error" not in result.output
 
 
 def test_unknown_profile_is_rejected_by_the_generator(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from croissant_baker.__main__ import app
+from tests.helpers import cli
 
 runner = CliRunner()
 
@@ -938,3 +939,186 @@ def test_baked_output_round_trips_through_mlcroissant(
     record_sets = list(ds.metadata.record_sets)
     fields = list(record_sets[0].fields)
     assert {f.name for f in fields} == {"id", "name", "age"}
+
+
+def test_identifier_single_value_emits_a_string(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """One --identifier emits a bare string, the shape a lone accession takes."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--identifier", "phs000218.v1.p1")
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["identifier"] == "phs000218.v1.p1"
+
+
+def test_identifier_repeated_and_comma_delimited_emits_a_list(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """--identifier accepts both input shapes, and several values become a list."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset,
+        output,
+        "--identifier",
+        "phs000218.v1.p1,EGAS00001000255",
+        "--identifier",
+        "https://doi.org/10.1234/example",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["identifier"] == [
+        "phs000218.v1.p1",
+        "EGAS00001000255",
+        "https://doi.org/10.1234/example",
+    ]
+
+
+def test_conditions_of_access_passes_through(csv_dataset: Path, tmp_path: Path) -> None:
+    """--conditions-of-access is free text; it reaches the output unchanged."""
+    output = tmp_path / "output.jsonld"
+    conditions = "Controlled access: Data Access Agreement via the DAC"
+
+    result = cli(csv_dataset, output, "--conditions-of-access", conditions)
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["conditionsOfAccess"] == conditions
+
+
+@pytest.mark.parametrize(
+    "flag,expected",
+    [("--is-accessible-for-free", True), ("--not-accessible-for-free", False)],
+)
+def test_is_accessible_for_free_emits_the_boolean_asked_for(
+    csv_dataset: Path, tmp_path: Path, flag: str, expected: bool
+) -> None:
+    """Both halves of the flag pair emit a JSON boolean, not a string."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, flag)
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["isAccessibleForFree"] is expected
+
+
+def test_included_in_data_catalog_passes_through(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """--included-in-data-catalog carries the catalog URL through verbatim."""
+    output = tmp_path / "output.jsonld"
+    catalog = "https://datacatalog.ccdi.cancer.gov/"
+
+    result = cli(csv_dataset, output, "--included-in-data-catalog", catalog)
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["includedInDataCatalog"] == catalog
+
+
+def test_profile_bioschemas_appends_to_conforms_to(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """--profile bioschemas declares the second profile alongside Croissant 1.1."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--profile", "bioschemas")
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["conformsTo"] == [
+        "http://mlcommons.org/croissant/1.1",
+        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+    ]
+
+
+def test_repeated_profile_is_declared_once(csv_dataset: Path, tmp_path: Path) -> None:
+    """A profile named twice is still one entry in conformsTo."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset, output, "--profile", "bioschemas", "--profile", "bioschemas"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["conformsTo"] == [
+        "http://mlcommons.org/croissant/1.1",
+        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+    ]
+
+
+def test_profile_coexists_with_rai_conformance(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """The RAI declaration appends to the profile list rather than replacing it."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset,
+        output,
+        "--profile",
+        "bioschemas",
+        "--rai-data-collection",
+        "Retrospective chart review",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["conformsTo"] == [
+        "http://mlcommons.org/croissant/1.1",
+        "https://bioschemas.org/profiles/Dataset/1.0-RELEASE",
+        "http://mlcommons.org/croissant/RAI/1.0",
+    ]
+
+
+def test_unknown_profile_is_rejected(csv_dataset: Path, tmp_path: Path) -> None:
+    """An unrecognised profile name fails loudly and names what is accepted."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output, "--profile", "biocroissant")
+
+    assert result.exit_code != 0
+    assert "bioschemas" in result.output
+
+
+def test_discovery_keys_absent_without_their_flags(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """None of the five appear unless asked for; optional keys stay absent."""
+    output = tmp_path / "output.jsonld"
+
+    result = cli(csv_dataset, output)
+
+    assert result.exit_code == 0, result.output
+    metadata = json.loads(output.read_text())
+    assert not {
+        "identifier",
+        "conditionsOfAccess",
+        "isAccessibleForFree",
+        "includedInDataCatalog",
+    } & set(metadata)
+    assert metadata["conformsTo"] == "http://mlcommons.org/croissant/1.1"
+
+
+def test_all_discovery_fields_construct_under_mlcroissant(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """An output carrying all five still loads as a Croissant dataset."""
+    import mlcroissant as mlc
+
+    output = tmp_path / "output.jsonld"
+
+    result = cli(
+        csv_dataset,
+        output,
+        "--identifier",
+        "phs000218.v1.p1,EGAS00001000255",
+        "--conditions-of-access",
+        "Controlled access: Data Access Agreement via the DAC",
+        "--not-accessible-for-free",
+        "--included-in-data-catalog",
+        "https://datacatalog.ccdi.cancer.gov/",
+        "--profile",
+        "bioschemas",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert mlc.Dataset(str(output)).metadata.name == "test_dataset"

--- a/tests/test_mlcroissant_api_gaps.py
+++ b/tests/test_mlcroissant_api_gaps.py
@@ -14,13 +14,25 @@ import inspect
 import mlcroissant as mlc
 
 
-# Fields the Croissant 1.1 spec defines that mlcroissant 1.1.0 does NOT expose
-# as Python parameters. Each is post-hoc-injected by MetadataGenerator.
+# Fields MetadataGenerator post-hoc-injects because mlcroissant 1.1.0 exposes
+# no Python parameter for them. Two kinds sit in one set: fields the Croissant
+# 1.1 spec itself defines (``alternate_name``, ``is_live_dataset``,
+# ``temporal_coverage``, ``usage_info``) and plain schema.org properties the
+# document reaches through the @vocab in its @context (``identifier``,
+# ``conditions_of_access``, ``is_accessible_for_free``,
+# ``included_in_data_catalog``). One set rather than two because the action
+# when the assertion fires is the same for both: switch that field to the
+# native parameter and delete its inject. The kinds differ only in how likely
+# mlcroissant is to close the gap.
 _METADATA_GAPS_AS_OF_MLC_1_1_0 = {
     "alternate_name",
     "is_live_dataset",
     "temporal_coverage",
     "usage_info",
+    "identifier",
+    "conditions_of_access",
+    "is_accessible_for_free",
+    "included_in_data_catalog",
 }
 
 

--- a/tests/test_mlcroissant_api_gaps.py
+++ b/tests/test_mlcroissant_api_gaps.py
@@ -84,6 +84,29 @@ def test_sd_version_native_param_still_emits_prefixed_key() -> None:
     assert "cr:sdVersion" in out
 
 
+def test_metadata_id_param_still_emits_no_top_level_id() -> None:
+    """``id`` is a native Metadata param, but ``to_json()`` writes no ``@id``
+    for the Dataset itself, so the document has no subject to name it by.
+    Profiles that require one — Bioschemas Dataset lists @id among its minimum
+    fields — need the key, so we post-hoc inject the dataset URL. When
+    mlcroissant starts emitting it, this test fails: drop the inject in
+    MetadataGenerator.generate_metadata.
+    """
+    md = mlc.Metadata(
+        id="https://example.com/dataset",
+        name="t",
+        description="d",
+        url="https://example.com/dataset",
+        license="mit",
+        conforms_to="http://mlcommons.org/croissant/1.1",
+    )
+    out = md.to_json()
+    assert "@id" not in out, (
+        "mlcroissant now emits a top-level @id. "
+        "Drop the post-hoc inject in MetadataGenerator.generate_metadata."
+    )
+
+
 def test_rai_conforms_to_not_auto_appended_when_rai_fields_set() -> None:
     """The Croissant 1.1 spec defines ``http://mlcommons.org/croissant/RAI/1.0``
     as the conformsTo URI for the RAI extension, but mlcroissant 1.1.0 does

--- a/tests/test_mlcroissant_api_gaps.py
+++ b/tests/test_mlcroissant_api_gaps.py
@@ -87,8 +87,8 @@ def test_sd_version_native_param_still_emits_prefixed_key() -> None:
 def test_metadata_id_param_still_emits_no_top_level_id() -> None:
     """``id`` is a native Metadata param, but ``to_json()`` writes no ``@id``
     for the Dataset itself, so the document has no subject to name it by.
-    Profiles that require one — Bioschemas Dataset lists @id among its minimum
-    fields — need the key, so we post-hoc inject the dataset URL. When
+    Profiles that require one (Bioschemas Dataset lists @id among its minimum
+    fields) need the key, so we post-hoc inject the dataset URL. When
     mlcroissant starts emitting it, this test fails: drop the inject in
     MetadataGenerator.generate_metadata.
     """


### PR DESCRIPTION
Closes #126.

Adds five user-supplied discovery and access fields, injected post-serialisation the same way `usageInfo` and `temporalCoverage` already are. Nothing is inferred; every value is an explicit CLI input, so the traceability guarantee is unchanged.

| Flag | JSON-LD key | Shape |
|------|-------------|-------|
| `--identifier` (repeatable or comma-delimited) | `identifier` | string, or list when several are given |
| `--conditions-of-access` | `conditionsOfAccess` | string |
| `--is-accessible-for-free` / `--not-accessible-for-free` | `isAccessibleForFree` | boolean; omitted when neither flag is given |
| `--included-in-data-catalog` | `includedInDataCatalog` | URL string |
| `--profile bioschemas` (repeatable) | appends the Bioschemas Dataset profile URI to `conformsTo` | list |

## Why

Controlled-access datasets can already be described locally and published as metadata only, but the output had no field saying how access is obtained, whether it is free, or which accession (dbGaP, EGA, DOI) the data sits under. `conditionsOfAccess` and `isAccessibleForFree` are rendered by Google Dataset Search; `includedInDataCatalog` lets a release point at its catalog entry; `identifier` carries the accession. `--profile bioschemas` declares the Bioschemas Dataset profile in `conformsTo` so ELIXIR-aligned biomedical discovery services can pick the document up, which the manuscript lists as future work.

## Design notes

- Profile names resolve through one `PROFILE_CONFORMS_TO` map in `metadata_generator.py`; the CLI rejects unknown names with `typer.BadParameter` and `MetadataGenerator` raises `ValueError` for library callers, so a bad name cannot surface as a `KeyError` at serialisation.
- `conformsTo` is built once via `_resolve_conforms_to()` (Croissant 1.1 first, then declared profiles, de-duplicated in order); the RAI URI is appended afterwards by the untouched `_ensure_rai_conforms_to`, so the emitted order is Croissant, Bioschemas, RAI.
- Profile names are normalised before validation, so a padded value such as `' bioschemas'` is accepted.
- `mlcroissant.Dataset` constructs on an output that uses all five fields and round-trips them, including the two-element `conformsTo`.

## Testing

- 14 new tests in `tests/test_cli.py`: one per flag, repeat and comma forms, tri-state boolean, absence guard (no new keys when no flag is given), `conformsTo` when it starts as a string or a list and when combined with `--rai-*`, unknown profile rejected on both the CLI and library paths, padded profile accepted, and an end-to-end bake validated under mlcroissant with the Bioschemas URI asserted after the round trip.
- `uv run pytest -v`: 857 passed. `uv run pre-commit run --all-files`: all hooks pass. `docs/generate.py` regenerated `docs/reference/cli.md`; the formats and RAI tables are unchanged.
