### PR TITLE
fix: refuse unknown RAI config keys and correct the social impact key in the template

### DIFF
--- a/docs/user-guide/rai.md
+++ b/docs/user-guide/rai.md
@@ -114,6 +114,10 @@ activities:
 
 A complete working example is at [`tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml`](https://github.com/MIT-LCP/croissant-baker/blob/main/tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml).
 
+### Unknown keys are rejected
+
+Every key is checked against the keys its section accepts, at every level of the file. A key that is not recognised stops the run with an error naming the key by its path in the YAML (for example `activities[0].agents[1].nme`) and listing the keys that section does accept. A misspelled key is therefore never dropped in silence, so a field cannot go missing from the output without a word. The config is read before the dataset is scanned, so the error arrives immediately.
+
 ## Apply RAI to an existing file
 
 You can inject RAI into a `.jsonld` file that was already generated:

--- a/docs/user-guide/rai.md
+++ b/docs/user-guide/rai.md
@@ -116,7 +116,7 @@ A complete working example is at [`tests/data/input/mimiciv_demo/physionet.org/m
 
 ### Unknown keys are rejected
 
-Every key is checked against the keys its section accepts, at every level of the file. A key that is not recognised stops the run with an error naming the key by its path in the YAML (for example `activities[0].agents[1].nme`) and listing the keys that section does accept. A misspelled key is therefore never dropped in silence, so a field cannot go missing from the output without a word. The config is read before the dataset is scanned, so the error arrives immediately.
+Every key is checked against the keys its section accepts, at every level of the file. A key that is not recognised stops the run with an error naming the key by its path in the YAML (for example `activities[0].agents[1].nme`) and listing the keys that section does accept. A misspelled key is therefore never dropped in silence, so a field cannot go missing from the output without a word. The config is read before the dataset is scanned, so the error arrives immediately, and `--dry-run` checks it too.
 
 ## Apply RAI to an existing file
 

--- a/docs/user-guide/rai.md
+++ b/docs/user-guide/rai.md
@@ -112,6 +112,8 @@ activities:
         url: https://lcp.mit.edu
 ```
 
+`collection_types` is written out as `rai:dataCollectionType` on the dataset node, unioned across every activity in declaration order, because RAI 1.0 declares that property on the dataset rather than on an activity.
+
 A complete working example is at [`tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml`](https://github.com/MIT-LCP/croissant-baker/blob/main/tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml).
 
 ### Unknown keys are rejected

--- a/rai-example.yaml
+++ b/rai-example.yaml
@@ -100,11 +100,13 @@ lineage:
 
   # rai:usedBy — models or assets that have used this dataset (e.g. for training
   # or evaluation). url is required; name and id are optional.
-  # Write `models: []` if no model has used the dataset yet.
-  models:
-    - url: https://huggingface.co/my-org/my-model
-      id: MODEL-001
-      name: My Clinical NLP Model
+  # An entry here asserts that a named model used this dataset, so the shape is
+  # shown as a comment: fill it in only for a model you know of.
+  models: []
+  # models:
+  #   - url: https://huggingface.co/my-org/my-model
+  #     name: My Clinical NLP Model
+  #     id: MODEL-001
 
 
 # ── Activities ────────────────────────────────────────────────────────────────

--- a/rai-example.yaml
+++ b/rai-example.yaml
@@ -72,7 +72,7 @@ ai_fairness:
   # Articulate what new capabilities the dataset enables, who benefits, potential
   # harms, affected groups, and concrete mitigation steps (licensing, access
   # controls, usage agreements).
-  social_impact: >
+  data_social_impact: >
     This dataset enables research that could improve clinical AI tools and
     patient outcomes. However, models trained on biased data risk perpetuating
     health disparities if deployed without careful evaluation. Access is

--- a/rai-example.yaml
+++ b/rai-example.yaml
@@ -90,19 +90,21 @@ lineage:
 
   # prov:wasDerivedFrom — datasets this dataset was derived from.
   # url is required; all other fields are optional.
+  # id is your own identifier for the source, if you use one.
   source_datasets:
     - url: https://physionet.org/content/mimiciii/
+      id: SOURCE-001
       name: MIMIC-III
       organisation: PhysioNet
       license: PhysioNet Credentialed Health Data License 1.5.0
 
   # rai:usedBy — models or assets that have used this dataset (e.g. for training
   # or evaluation). url is required; name and id are optional.
-  models: []
-  # models:
-  #   - url: https://huggingface.co/my-org/my-model
-  #     name: My Clinical NLP Model
-  #     id: MODEL-001
+  # Write `models: []` if no model has used the dataset yet.
+  models:
+    - url: https://huggingface.co/my-org/my-model
+      id: MODEL-001
+      name: My Clinical NLP Model
 
 
 # ── Activities ────────────────────────────────────────────────────────────────
@@ -145,6 +147,7 @@ activities:
         is_synthetic: false
     platforms:
       - name: Hospital Electronic Health Record System
+        url: https://www.bidmc.org
         description: >
           Institutional EHR system used for routine clinical documentation,
           from which the raw data was extracted.

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -831,6 +831,18 @@ def main(
             )
             raise typer.Exit(code=1)
 
+        # Read the RAI config before scanning: it is an input, so a typo in it
+        # should be reported now rather than after a bake that gets discarded.
+        rai = None
+        if rai_config:
+            from croissant_baker.rai import load_rai_config
+
+            try:
+                rai = load_rai_config(rai_config)
+            except ValueError as exc:
+                typer.echo(f"Error: {exc}", err=True)
+                raise typer.Exit(code=1)
+
         # Parse creators following mlcroissant specification
         # Allows flexible Person/Organization objects with optional properties
         parsed_creators = []
@@ -944,10 +956,9 @@ def main(
             )
 
         # Inject RAI attributes when a config file is provided
-        if rai_config:
-            from croissant_baker.rai import inject_rai, load_rai_config
+        if rai is not None:
+            from croissant_baker.rai import inject_rai
 
-            rai = load_rai_config(rai_config)
             metadata_dict = inject_rai(metadata_dict, rai)
 
         _ensure_rai_conforms_to(
@@ -996,6 +1007,9 @@ def main(
             date_published=date_published,
         )
 
+    except typer.Exit:
+        # Already reported by whoever raised it; do not relabel it below.
+        raise
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         # A bake that described nothing is when coverage matters most.

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -755,6 +755,51 @@ def main(
         )
         raise typer.Exit(code=1)
 
+    # The RAI inputs are read before anything looks at the dataset: they are
+    # inputs like any other flag, so a conflict or a typo in the config is
+    # reported now, including under --dry-run, and not after a discarded bake.
+    try:
+        native_rai_fields = _build_native_rai_fields(
+            rai_data_collection=rai_data_collection,
+            rai_data_collection_type=rai_data_collection_type,
+            rai_data_collection_missing_data=rai_data_collection_missing_data,
+            rai_data_collection_raw_data=rai_data_collection_raw_data,
+            rai_data_collection_timeframe=rai_data_collection_timeframe,
+            rai_data_imputation_protocol=rai_data_imputation_protocol,
+            rai_data_preprocessing_protocol=rai_data_preprocessing_protocol,
+            rai_data_manipulation_protocol=rai_data_manipulation_protocol,
+            rai_data_annotation_protocol=rai_data_annotation_protocol,
+            rai_data_annotation_platform=rai_data_annotation_platform,
+            rai_data_annotation_analysis=rai_data_annotation_analysis,
+            rai_annotations_per_item=rai_annotations_per_item,
+            rai_annotator_demographics=rai_annotator_demographics,
+            rai_machine_annotation_tools=rai_machine_annotation_tools,
+            rai_data_biases=rai_data_biases,
+            rai_data_use_cases=rai_data_use_cases,
+            rai_data_limitations=rai_data_limitations,
+            rai_data_social_impact=rai_data_social_impact,
+            rai_personal_sensitive_information=rai_personal_sensitive_information,
+            rai_data_release_maintenance_plan=rai_data_release_maintenance_plan,
+        )
+
+        if rai_config and native_rai_fields:
+            typer.echo(
+                "Error: native --rai-* flags cannot be combined with --rai-config. "
+                "Use direct flags for native mlcroissant RAI fields, or --rai-config "
+                "for the richer YAML-based workflow.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        rai = None
+        if rai_config:
+            from croissant_baker.rai import load_rai_config
+
+            rai = load_rai_config(rai_config)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1)
+
     # Listing every file is the point of this mode, so the fixed-size rule
     # governing the default bake summary does not apply here.
     if dry_run:
@@ -799,50 +844,6 @@ def main(
 
     generator: Optional[MetadataGenerator] = None
     try:
-        native_rai_fields = _build_native_rai_fields(
-            rai_data_collection=rai_data_collection,
-            rai_data_collection_type=rai_data_collection_type,
-            rai_data_collection_missing_data=rai_data_collection_missing_data,
-            rai_data_collection_raw_data=rai_data_collection_raw_data,
-            rai_data_collection_timeframe=rai_data_collection_timeframe,
-            rai_data_imputation_protocol=rai_data_imputation_protocol,
-            rai_data_preprocessing_protocol=rai_data_preprocessing_protocol,
-            rai_data_manipulation_protocol=rai_data_manipulation_protocol,
-            rai_data_annotation_protocol=rai_data_annotation_protocol,
-            rai_data_annotation_platform=rai_data_annotation_platform,
-            rai_data_annotation_analysis=rai_data_annotation_analysis,
-            rai_annotations_per_item=rai_annotations_per_item,
-            rai_annotator_demographics=rai_annotator_demographics,
-            rai_machine_annotation_tools=rai_machine_annotation_tools,
-            rai_data_biases=rai_data_biases,
-            rai_data_use_cases=rai_data_use_cases,
-            rai_data_limitations=rai_data_limitations,
-            rai_data_social_impact=rai_data_social_impact,
-            rai_personal_sensitive_information=rai_personal_sensitive_information,
-            rai_data_release_maintenance_plan=rai_data_release_maintenance_plan,
-        )
-
-        if rai_config and native_rai_fields:
-            typer.echo(
-                "Error: native --rai-* flags cannot be combined with --rai-config. "
-                "Use direct flags for native mlcroissant RAI fields, or --rai-config "
-                "for the richer YAML-based workflow.",
-                err=True,
-            )
-            raise typer.Exit(code=1)
-
-        # Read the RAI config before scanning: it is an input, so a typo in it
-        # should be reported now rather than after a bake that gets discarded.
-        rai = None
-        if rai_config:
-            from croissant_baker.rai import load_rai_config
-
-            try:
-                rai = load_rai_config(rai_config)
-            except ValueError as exc:
-                typer.echo(f"Error: {exc}", err=True)
-                raise typer.Exit(code=1)
-
         # Parse creators following mlcroissant specification
         # Allows flexible Person/Organization objects with optional properties
         parsed_creators = []

--- a/src/croissant_baker/rai/injector.py
+++ b/src/croissant_baker/rai/injector.py
@@ -36,8 +36,9 @@ def inject_rai(metadata: dict, config: RAIConfig) -> dict:
     - Models that used this dataset → rai:usedBy.
     - Activities → prov:wasGeneratedBy (list of prov:Activity), each with
       optional prov:wasAssociatedWith (agents) and rai:usedPlatform (platforms).
-    - Collection types → rai:dataCollectionType, on each activity that declares
-      one and, unioned, on the dataset node the RAI spec puts the property on.
+    - Collection types → rai:dataCollectionType on the dataset node, unioned
+      across the activities. RAI 1.0 declares the property on sc:Dataset, so
+      it does not go on the prov:Activity that carries the types in the config.
     """
     _ensure_prov_context(metadata, config)
 
@@ -56,8 +57,8 @@ def inject_rai(metadata: dict, config: RAIConfig) -> dict:
     if af.has_synthetic_data is not None:
         metadata["rai:hasSyntheticData"] = af.has_synthetic_data
 
-    # rai:dataCollectionType is a dataset-level property, so the activities'
-    # types are unioned onto the dataset as well as kept on their own nodes.
+    # rai:dataCollectionType is declared on sc:Dataset, so the types every
+    # activity declares are unioned onto the dataset rather than left on it.
     collection_types = _unique(
         t for act in config.activities for t in act.collection_types
     )
@@ -127,8 +128,6 @@ def _build_activity(act: Activity) -> dict:
         node["prov:startedAtTime"] = act.start_at
     if act.end_at:
         node["prov:endedAtTime"] = act.end_at
-    if act.collection_types:
-        node["rai:dataCollectionType"] = _one_or_many(_unique(act.collection_types))
 
     if act.agents:
         agent_nodes = []

--- a/src/croissant_baker/rai/injector.py
+++ b/src/croissant_baker/rai/injector.py
@@ -13,6 +13,16 @@ _ACTIVITY_LABELS = {
 }
 
 
+def _one_or_many(values: list):
+    """Croissant writes a single-valued property as a scalar, not a list."""
+    return values[0] if len(values) == 1 else values
+
+
+def _unique(values) -> list:
+    """The values in declaration order, first occurrence kept."""
+    return list(dict.fromkeys(values))
+
+
 def inject_rai(metadata: dict, config: RAIConfig) -> dict:
     """
     Inject RAI and PROV-O attributes into a Croissant metadata dict.
@@ -26,6 +36,8 @@ def inject_rai(metadata: dict, config: RAIConfig) -> dict:
     - Models that used this dataset → rai:usedBy.
     - Activities → prov:wasGeneratedBy (list of prov:Activity), each with
       optional prov:wasAssociatedWith (agents) and rai:usedPlatform (platforms).
+    - Collection types → rai:dataCollectionType, on each activity that declares
+      one and, unioned, on the dataset node the RAI spec puts the property on.
     """
     _ensure_prov_context(metadata, config)
 
@@ -43,6 +55,14 @@ def inject_rai(metadata: dict, config: RAIConfig) -> dict:
         metadata["rai:dataSocialImpact"] = af.data_social_impact
     if af.has_synthetic_data is not None:
         metadata["rai:hasSyntheticData"] = af.has_synthetic_data
+
+    # rai:dataCollectionType is a dataset-level property, so the activities'
+    # types are unioned onto the dataset as well as kept on their own nodes.
+    collection_types = _unique(
+        t for act in config.activities for t in act.collection_types
+    )
+    if collection_types:
+        metadata["rai:dataCollectionType"] = _one_or_many(collection_types)
 
     # Lineage — source datasets
     if config.lineage.source_datasets:
@@ -68,9 +88,7 @@ def inject_rai(metadata: dict, config: RAIConfig) -> dict:
     # Activities
     activities = [_build_activity(act) for act in config.activities]
     if activities:
-        metadata["prov:wasGeneratedBy"] = (
-            activities[0] if len(activities) == 1 else activities
-        )
+        metadata["prov:wasGeneratedBy"] = _one_or_many(activities)
 
     return metadata
 
@@ -109,6 +127,8 @@ def _build_activity(act: Activity) -> dict:
         node["prov:startedAtTime"] = act.start_at
     if act.end_at:
         node["prov:endedAtTime"] = act.end_at
+    if act.collection_types:
+        node["rai:dataCollectionType"] = _one_or_many(_unique(act.collection_types))
 
     if act.agents:
         agent_nodes = []
@@ -120,9 +140,7 @@ def _build_activity(act: Activity) -> dict:
             if a.description:
                 agent["prov:description"] = a.description
             agent_nodes.append(agent)
-        node["prov:wasAssociatedWith"] = (
-            agent_nodes[0] if len(agent_nodes) == 1 else agent_nodes
-        )
+        node["prov:wasAssociatedWith"] = _one_or_many(agent_nodes)
 
     if act.platforms:
         platform_nodes = []
@@ -133,9 +151,7 @@ def _build_activity(act: Activity) -> dict:
             if p.description:
                 plat["prov:description"] = p.description
             platform_nodes.append(plat)
-        node["rai:usedPlatform"] = (
-            platform_nodes[0] if len(platform_nodes) == 1 else platform_nodes
-        )
+        node["rai:usedPlatform"] = _one_or_many(platform_nodes)
 
     return node
 

--- a/src/croissant_baker/rai/loader.py
+++ b/src/croissant_baker/rai/loader.py
@@ -80,6 +80,31 @@ def _entries(value, path: str, file: Path) -> list[dict]:
     return [_mapping(entry, f"{path}[{i}]", file) for i, entry in enumerate(value)]
 
 
+def _scalars(value, path: str, file: Path) -> list[str]:
+    """Return ``value`` as a list of plain values, dropping the blank ones.
+
+    A bare string is refused rather than iterated: its characters are never
+    what the author meant, and a mapping's keys are not either.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(
+            f"{file}: expected a list of values at {path}, "
+            f"found {type(value).__name__}."
+        )
+    scalars = []
+    for i, item in enumerate(value):
+        if isinstance(item, (dict, list)):
+            raise ValueError(
+                f"{file}: expected a value at {path}[{i}], found {type(item).__name__}."
+            )
+        text = _str(item)
+        if text:
+            scalars.append(text)
+    return scalars
+
+
 def _load_yaml(path: Path):
     try:
         with open(path, encoding="utf-8") as fh:
@@ -184,9 +209,9 @@ def load_rai_config(path: Path) -> RAIConfig:
                 )
             )
 
-        collection_types = [
-            str(t).strip() for t in (act_raw.get("collection_types") or []) if t
-        ]
+        collection_types = _scalars(
+            act_raw.get("collection_types"), f"{act_path}.collection_types", path
+        )
 
         activities.append(
             Activity(

--- a/src/croissant_baker/rai/loader.py
+++ b/src/croissant_baker/rai/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import fields as dataclass_fields
 from pathlib import Path
 from typing import Optional
 
@@ -19,6 +20,21 @@ from croissant_baker.rai.schema import (
 )
 
 
+def _accepted(cls) -> frozenset[str]:
+    """The YAML keys a level accepts: the field names of its dataclass."""
+    return frozenset(f.name for f in dataclass_fields(cls))
+
+
+_TOP_LEVEL_KEYS = _accepted(RAIConfig)
+_FAIRNESS_KEYS = _accepted(AIFairnessConfig)
+_LINEAGE_KEYS = _accepted(LineageConfig)
+_SOURCE_DATASET_KEYS = _accepted(SourceDataset)
+_MODEL_KEYS = _accepted(ModelRef)
+_ACTIVITY_KEYS = _accepted(Activity)
+_AGENT_KEYS = _accepted(Agent)
+_PLATFORM_KEYS = _accepted(Platform)
+
+
 def _str(value) -> Optional[str]:
     if value is None:
         return None
@@ -26,13 +42,60 @@ def _str(value) -> Optional[str]:
     return s if s else None
 
 
+def _mapping(value, path: str, file: Path) -> dict:
+    """Return ``value`` as a mapping, or fail naming where one was expected."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"{file}: expected a mapping at {path or 'the top level'}, "
+            f"found {type(value).__name__}."
+        )
+    return value
+
+
+def _check_keys(mapping: dict, allowed: frozenset[str], path: str, file: Path) -> None:
+    """Refuse a key this level does not read, rather than dropping it silently."""
+    unknown = sorted(key for key in mapping if key not in allowed)
+    if not unknown:
+        return
+    prefix = f"{path}." if path else ""
+    listed = ", ".join(f"{prefix}{key}" for key in unknown)
+    accepted = ", ".join(sorted(allowed))
+    label = "key" if len(unknown) == 1 else "keys"
+    raise ValueError(
+        f"{file}: unknown {label} in the RAI config: {listed}. "
+        f"Accepted keys at {path or 'the top level'}: {accepted}."
+    )
+
+
+def _entries(value, path: str, file: Path) -> list[dict]:
+    """Return ``value`` as a list of mappings, one per numbered entry."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(
+            f"{file}: expected a list at {path}, found {type(value).__name__}."
+        )
+    return [_mapping(entry, f"{path}[{i}]", file) for i, entry in enumerate(value)]
+
+
+def _load_yaml(path: Path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: invalid YAML: {exc}") from exc
+
+
 def load_rai_config(path: Path) -> RAIConfig:
     """Load a RAI YAML config file and return a RAIConfig instance."""
-    with open(path, encoding="utf-8") as fh:
-        raw = yaml.safe_load(fh) or {}
+    raw = _mapping(_load_yaml(path), "", path)
+    _check_keys(raw, _TOP_LEVEL_KEYS, "", path)
 
     # AI Safety and Fairness
-    af_raw = raw.get("ai_fairness") or {}
+    af_raw = _mapping(raw.get("ai_fairness"), "ai_fairness", path)
+    _check_keys(af_raw, _FAIRNESS_KEYS, "ai_fairness", path)
     ai_fairness = AIFairnessConfig(
         data_limitations=_str(af_raw.get("data_limitations")),
         data_biases=_str(af_raw.get("data_biases")),
@@ -47,55 +110,79 @@ def load_rai_config(path: Path) -> RAIConfig:
     )
 
     # Lineage
-    ln_raw = raw.get("lineage") or {}
+    ln_raw = _mapping(raw.get("lineage"), "lineage", path)
+    _check_keys(ln_raw, _LINEAGE_KEYS, "lineage", path)
 
-    source_datasets = [
-        SourceDataset(
-            url=str(s.get("url", "")),
-            id=_str(s.get("id")),
-            name=_str(s.get("name")),
-            organisation=_str(s.get("organisation")),
-            license=_str(s.get("license")),
+    source_datasets = []
+    for i, s in enumerate(
+        _entries(ln_raw.get("source_datasets"), "lineage.source_datasets", path)
+    ):
+        _check_keys(s, _SOURCE_DATASET_KEYS, f"lineage.source_datasets[{i}]", path)
+        if not s.get("url"):
+            continue
+        source_datasets.append(
+            SourceDataset(
+                url=str(s.get("url", "")),
+                id=_str(s.get("id")),
+                name=_str(s.get("name")),
+                organisation=_str(s.get("organisation")),
+                license=_str(s.get("license")),
+            )
         )
-        for s in (ln_raw.get("source_datasets") or [])
-        if s.get("url")
-    ]
 
-    models = [
-        ModelRef(
-            url=str(m.get("url", "")),
-            id=_str(m.get("id")),
-            name=_str(m.get("name")),
+    models = []
+    for i, m in enumerate(_entries(ln_raw.get("models"), "lineage.models", path)):
+        _check_keys(m, _MODEL_KEYS, f"lineage.models[{i}]", path)
+        if not m.get("url"):
+            continue
+        models.append(
+            ModelRef(
+                url=str(m.get("url", "")),
+                id=_str(m.get("id")),
+                name=_str(m.get("name")),
+            )
         )
-        for m in (ln_raw.get("models") or [])
-        if m.get("url")
-    ]
 
     lineage = LineageConfig(source_datasets=source_datasets, models=models)
 
     # Activities
     activities = []
-    for act_raw in raw.get("activities") or []:
-        agents = [
-            Agent(
-                name=str(a.get("name", "")),
-                url=_str(a.get("url")),
-                description=_str(a.get("description")),
-                is_synthetic=bool(a.get("is_synthetic", False)),
-            )
-            for a in (act_raw.get("agents") or [])
-            if a.get("name")
-        ]
+    for act_index, act_raw in enumerate(
+        _entries(raw.get("activities"), "activities", path)
+    ):
+        act_path = f"activities[{act_index}]"
+        _check_keys(act_raw, _ACTIVITY_KEYS, act_path, path)
 
-        platforms = [
-            Platform(
-                name=str(p.get("name", "")),
-                url=_str(p.get("url")),
-                description=_str(p.get("description")),
+        agents = []
+        for i, a in enumerate(
+            _entries(act_raw.get("agents"), f"{act_path}.agents", path)
+        ):
+            _check_keys(a, _AGENT_KEYS, f"{act_path}.agents[{i}]", path)
+            if not a.get("name"):
+                continue
+            agents.append(
+                Agent(
+                    name=str(a.get("name", "")),
+                    url=_str(a.get("url")),
+                    description=_str(a.get("description")),
+                    is_synthetic=bool(a.get("is_synthetic", False)),
+                )
             )
-            for p in (act_raw.get("platforms") or [])
-            if p.get("name")
-        ]
+
+        platforms = []
+        for i, p in enumerate(
+            _entries(act_raw.get("platforms"), f"{act_path}.platforms", path)
+        ):
+            _check_keys(p, _PLATFORM_KEYS, f"{act_path}.platforms[{i}]", path)
+            if not p.get("name"):
+                continue
+            platforms.append(
+                Platform(
+                    name=str(p.get("name", "")),
+                    url=_str(p.get("url")),
+                    description=_str(p.get("description")),
+                )
+            )
 
         collection_types = [
             str(t).strip() for t in (act_raw.get("collection_types") or []) if t

--- a/tests/data/output/mimiciv_demo_croissant_rai.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant_rai.jsonld
@@ -5790,6 +5790,10 @@
   "rai:dataUseCases": "Benchmarking clinical natural language processing and machine learning models. Supporting research into hospital readmission, mortality prediction, and clinical decision support. Not intended for direct clinical decision-making.",
   "rai:dataSocialImpact": "This dataset enables research that could improve clinical AI tools and patient outcomes. However, models trained on biased data risk perpetuating health disparities if deployed without careful evaluation.",
   "rai:hasSyntheticData": false,
+  "rai:dataCollectionType": [
+    "observations",
+    "existing_datasets"
+  ],
   "prov:wasDerivedFrom": [
     {
       "url": "https://physionet.org/content/mimiciii/",
@@ -5809,6 +5813,10 @@
       "prov:description": "Retrospective electronic health records collected during routine clinical care at Beth Israel Deaconess Medical Center.",
       "prov:startedAtTime": "2011-01-01",
       "prov:endedAtTime": "2019-12-31",
+      "rai:dataCollectionType": [
+        "observations",
+        "existing_datasets"
+      ],
       "prov:wasAssociatedWith": {
         "@type": "prov:Agent",
         "name": "Beth Israel Deaconess Medical Center Clinical Team",

--- a/tests/data/output/mimiciv_demo_croissant_rai.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant_rai.jsonld
@@ -5813,10 +5813,6 @@
       "prov:description": "Retrospective electronic health records collected during routine clinical care at Beth Israel Deaconess Medical Center.",
       "prov:startedAtTime": "2011-01-01",
       "prov:endedAtTime": "2019-12-31",
-      "rai:dataCollectionType": [
-        "observations",
-        "existing_datasets"
-      ],
       "prov:wasAssociatedWith": {
         "@type": "prov:Agent",
         "name": "Beth Israel Deaconess Medical Center Clinical Team",

--- a/tests/test_rai.py
+++ b/tests/test_rai.py
@@ -7,6 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from croissant_baker.__main__ import app
+from tests.helpers import cli
 
 runner = CliRunner()
 
@@ -93,3 +94,93 @@ def test_rai_generation_matches_reference(
 
     for key in _RAI_PROV_KEYS:
         assert generated.get(key) == expected.get(key), f"Mismatch for {key}"
+
+
+BAD_RAI_YAML = "ai_fairness:\n  social_impact: It enables research.\n"
+
+
+def _bad_config(tmp_path: Path) -> Path:
+    path = tmp_path / "rai.yaml"
+    path.write_text(BAD_RAI_YAML, encoding="utf-8")
+    return path
+
+
+def test_generate_reports_a_bad_rai_config_without_a_traceback(tmp_path: Path) -> None:
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    (dataset / "data.csv").write_text("id,name\n1,Ada\n", encoding="utf-8")
+
+    result = cli(
+        dataset,
+        tmp_path / "out.jsonld",
+        "--rai-config",
+        str(_bad_config(tmp_path)),
+    )
+
+    assert result.exit_code == 1
+    assert "ai_fairness.social_impact" in result.stderr
+    assert "data_social_impact" in result.stderr
+    assert "Traceback" not in result.stderr + result.output
+    assert not isinstance(result.exception, ValueError)
+
+
+def test_rai_apply_reports_a_bad_rai_config_without_a_traceback(tmp_path: Path) -> None:
+    document = tmp_path / "croissant.jsonld"
+    document.write_text(json.dumps({"@context": {}, "name": "test"}), encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "rai-apply",
+            str(document),
+            "--rai-config",
+            str(_bad_config(tmp_path)),
+            "--no-validate",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "ai_fairness.social_impact" in result.stderr
+    assert "data_social_impact" in result.stderr
+    assert "Traceback" not in result.stderr + result.output
+    assert not isinstance(result.exception, ValueError)
+
+
+def test_a_bad_rai_config_is_reported_before_the_dataset_is_scanned(
+    tmp_path: Path,
+) -> None:
+    """The config is an input, not a result: checking it after a bake is wasted work."""
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    (dataset / "data.csv").write_text("id,name\n1,Ada\n", encoding="utf-8")
+
+    result = cli(
+        dataset,
+        tmp_path / "out.jsonld",
+        "--rai-config",
+        str(_bad_config(tmp_path)),
+    )
+
+    assert result.exit_code == 1
+    assert "Scanned" not in result.output
+
+
+def test_an_intended_exit_is_not_reported_as_an_unexpected_error(
+    tmp_path: Path,
+) -> None:
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    (dataset / "data.csv").write_text("id,name\n1,Ada\n", encoding="utf-8")
+
+    result = cli(
+        dataset,
+        tmp_path / "out.jsonld",
+        "--rai-config",
+        str(_bad_config(tmp_path)),
+        "--rai-data-biases",
+        "Single site",
+    )
+
+    assert result.exit_code == 1
+    assert "cannot be combined with --rai-config" in result.stderr
+    assert "Unexpected error" not in result.stderr

--- a/tests/test_rai.py
+++ b/tests/test_rai.py
@@ -7,6 +7,8 @@ import pytest
 from typer.testing import CliRunner
 
 from croissant_baker.__main__ import app
+from croissant_baker.rai import inject_rai
+from croissant_baker.rai.schema import Activity, RAIConfig
 from tests.helpers import cli
 
 runner = CliRunner()
@@ -33,6 +35,7 @@ _RAI_PROV_KEYS = [
     "rai:personalSensitiveInformation",
     "rai:dataUseCases",
     "rai:dataSocialImpact",
+    "rai:dataCollectionType",
     "prov:wasDerivedFrom",
 ]
 
@@ -184,3 +187,64 @@ def test_an_intended_exit_is_not_reported_as_an_unexpected_error(
     assert result.exit_code == 1
     assert "cannot be combined with --rai-config" in result.stderr
     assert "Unexpected error" not in result.stderr
+
+
+def _config(*activities: Activity) -> RAIConfig:
+    return RAIConfig(activities=list(activities))
+
+
+def _activity(identifier: str, *collection_types: str) -> Activity:
+    return Activity(
+        id=identifier,
+        type="data_collection",
+        collection_types=list(collection_types),
+    )
+
+
+def test_collection_types_reach_the_dataset_node() -> None:
+    """rai:dataCollectionType is a dataset-level property in RAI 1.0."""
+    config = _config(
+        _activity("ACT-001", "observations", "existing_datasets"),
+        _activity("ACT-002", "existing_datasets", "surveys"),
+    )
+
+    document = inject_rai({"@context": {}}, config)
+
+    assert document["rai:dataCollectionType"] == [
+        "observations",
+        "existing_datasets",
+        "surveys",
+    ]
+
+
+def test_a_single_collection_type_is_written_as_a_string() -> None:
+    document = inject_rai({"@context": {}}, _config(_activity("ACT-001", "surveys")))
+
+    assert document["rai:dataCollectionType"] == "surveys"
+
+
+def test_no_collection_types_writes_no_key() -> None:
+    document = inject_rai({"@context": {}}, _config(_activity("ACT-001")))
+
+    assert "rai:dataCollectionType" not in document
+
+
+def test_each_activity_node_carries_its_own_collection_types() -> None:
+    config = _config(
+        _activity("ACT-001", "observations", "existing_datasets"),
+        _activity("ACT-002"),
+    )
+
+    activities = inject_rai({"@context": {}}, config)["prov:wasGeneratedBy"]
+
+    assert activities[0]["rai:dataCollectionType"] == [
+        "observations",
+        "existing_datasets",
+    ]
+    assert "rai:dataCollectionType" not in activities[1]
+
+
+def test_the_reference_output_records_the_fixture_collection_types() -> None:
+    expected = json.loads(EXPECTED.read_text())
+
+    assert expected["rai:dataCollectionType"] == ["observations", "existing_datasets"]

--- a/tests/test_rai.py
+++ b/tests/test_rai.py
@@ -229,7 +229,9 @@ def test_no_collection_types_writes_no_key() -> None:
     assert "rai:dataCollectionType" not in document
 
 
-def test_each_activity_node_carries_its_own_collection_types() -> None:
+def test_no_activity_node_carries_collection_types() -> None:
+    """RAI 1.0 declares the property on sc:Dataset, so a prov:Activity is
+    outside its domain and must not carry a copy."""
     config = _config(
         _activity("ACT-001", "observations", "existing_datasets"),
         _activity("ACT-002"),
@@ -237,11 +239,7 @@ def test_each_activity_node_carries_its_own_collection_types() -> None:
 
     activities = inject_rai({"@context": {}}, config)["prov:wasGeneratedBy"]
 
-    assert activities[0]["rai:dataCollectionType"] == [
-        "observations",
-        "existing_datasets",
-    ]
-    assert "rai:dataCollectionType" not in activities[1]
+    assert all("rai:dataCollectionType" not in act for act in activities)
 
 
 def test_the_reference_output_records_the_fixture_collection_types() -> None:

--- a/tests/test_rai.py
+++ b/tests/test_rai.py
@@ -248,3 +248,25 @@ def test_the_reference_output_records_the_fixture_collection_types() -> None:
     expected = json.loads(EXPECTED.read_text())
 
     assert expected["rai:dataCollectionType"] == ["observations", "existing_datasets"]
+
+
+def test_a_dry_run_checks_the_rai_config_too(tmp_path: Path) -> None:
+    """A dry run is how a user checks a command before committing to it."""
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    (dataset / "data.csv").write_text("id,name\n1,Ada\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(dataset),
+            "--dry-run",
+            "--rai-config",
+            str(_bad_config(tmp_path)),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "ai_fairness.social_impact" in result.stderr
+    assert "would be processed" not in result.output

--- a/tests/test_rai_loader.py
+++ b/tests/test_rai_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from croissant_baker.rai import schema
 from croissant_baker.rai.loader import load_rai_config
 from croissant_baker.rai.schema import AIFairnessConfig
 
@@ -20,19 +21,55 @@ def write_config(tmp_path: Path, body: str) -> Path:
     return path
 
 
-def test_shipped_example_populates_every_fairness_field() -> None:
-    """Every key in the template must be one the loader actually reads.
+def _collect(value, found: dict) -> dict:
+    """Group every dataclass instance reachable from ``value`` by its class."""
+    if dataclasses.is_dataclass(value):
+        found.setdefault(type(value), []).append(value)
+        for f in dataclasses.fields(value):
+            _collect(getattr(value, f.name), found)
+    elif isinstance(value, list):
+        for item in value:
+            _collect(item, found)
+    return found
 
-    ``--rai-config --help`` points users at ``rai-example.yaml``, so a key the
-    loader does not know is a field silently missing from their output.
+
+def _is_set(value) -> bool:
+    """A field the template actually says something about.
+
+    ``False`` counts: ``has_synthetic_data: false`` is a deliberate answer,
+    not an omission. An empty string or list is not.
     """
-    config = load_rai_config(RAI_EXAMPLE)
+    if value is None:
+        return False
+    if isinstance(value, (str, list)):
+        return bool(value)
+    return True
 
-    unset = [
-        f.name
-        for f in dataclasses.fields(AIFairnessConfig)
-        if getattr(config.ai_fairness, f.name) is None
-    ]
+
+def test_shipped_example_exercises_every_schema_field() -> None:
+    """The template has to show every field the config can carry.
+
+    ``--rai-config --help`` points users at ``rai-example.yaml``, so a field
+    missing from it is a field they will never know they could have filled in,
+    and a key it spells wrong is one silently dropped from their output.
+    """
+    found = _collect(load_rai_config(RAI_EXAMPLE), {})
+
+    declared = {
+        obj
+        for obj in vars(schema).values()
+        if dataclasses.is_dataclass(obj) and obj.__module__ == schema.__name__
+    }
+    assert sorted(c.__name__ for c in declared - set(found)) == [], (
+        "a schema dataclass has no entry in the template"
+    )
+
+    unset = sorted(
+        f"{cls.__name__}.{f.name}"
+        for cls in declared
+        for f in dataclasses.fields(cls)
+        if not any(_is_set(getattr(instance, f.name)) for instance in found[cls])
+    )
     assert unset == []
 
 

--- a/tests/test_rai_loader.py
+++ b/tests/test_rai_loader.py
@@ -6,6 +6,7 @@ import dataclasses
 from pathlib import Path
 
 import pytest
+import yaml
 
 from croissant_baker.rai import schema
 from croissant_baker.rai.loader import load_rai_config
@@ -21,56 +22,64 @@ def write_config(tmp_path: Path, body: str) -> Path:
     return path
 
 
-def _collect(value, found: dict) -> dict:
-    """Group every dataclass instance reachable from ``value`` by its class."""
-    if dataclasses.is_dataclass(value):
-        found.setdefault(type(value), []).append(value)
-        for f in dataclasses.fields(value):
-            _collect(getattr(value, f.name), found)
-    elif isinstance(value, list):
-        for item in value:
-            _collect(item, found)
-    return found
+#: A schema dataclass the template is not required to fill in, and why.
+EXEMPT_FROM_TEMPLATE = {
+    "ModelRef": (
+        "a models entry asserts that a third party used the dataset, which no "
+        "template can know, so the template shows the fields in a comment"
+    )
+}
 
 
-def _is_set(value) -> bool:
-    """A field the template actually says something about.
+def _template_mappings(raw: dict) -> dict[str, list[dict]]:
+    """Every mapping in the template, grouped by the dataclass that reads it.
 
-    ``False`` counts: ``has_synthetic_data: false`` is a deliberate answer,
-    not an omission. An empty string or list is not.
+    Read off the raw YAML rather than the loaded config, so a field counts as
+    shown only when the template literally names the key. A loaded value cannot
+    tell the two apart: ``is_synthetic`` defaults to False whether the author
+    wrote ``false`` or wrote nothing.
     """
-    if value is None:
-        return False
-    if isinstance(value, (str, list)):
-        return bool(value)
-    return True
+    lineage = raw.get("lineage") or {}
+    activities = raw.get("activities") or []
+    return {
+        "RAIConfig": [raw],
+        "AIFairnessConfig": [raw.get("ai_fairness") or {}],
+        "LineageConfig": [lineage],
+        "SourceDataset": lineage.get("source_datasets") or [],
+        "ModelRef": lineage.get("models") or [],
+        "Activity": activities,
+        "Agent": [a for act in activities for a in act.get("agents") or []],
+        "Platform": [p for act in activities for p in act.get("platforms") or []],
+    }
 
 
-def test_shipped_example_exercises_every_schema_field() -> None:
+def test_shipped_example_names_every_schema_field() -> None:
     """The template has to show every field the config can carry.
 
     ``--rai-config --help`` points users at ``rai-example.yaml``, so a field
     missing from it is a field they will never know they could have filled in,
     and a key it spells wrong is one silently dropped from their output.
     """
-    found = _collect(load_rai_config(RAI_EXAMPLE), {})
+    raw = yaml.safe_load(RAI_EXAMPLE.read_text(encoding="utf-8"))
+    mappings = _template_mappings(raw)
 
     declared = {
-        obj
+        obj.__name__: obj
         for obj in vars(schema).values()
         if dataclasses.is_dataclass(obj) and obj.__module__ == schema.__name__
     }
-    assert sorted(c.__name__ for c in declared - set(found)) == [], (
-        "a schema dataclass has no entry in the template"
+    assert sorted(mappings) == sorted(declared), (
+        "a schema dataclass has nowhere to be read from in the template"
     )
 
-    unset = sorted(
-        f"{cls.__name__}.{f.name}"
-        for cls in declared
-        for f in dataclasses.fields(cls)
-        if not any(_is_set(getattr(instance, f.name)) for instance in found[cls])
+    unnamed = sorted(
+        f"{name}.{f.name}"
+        for name, entries in mappings.items()
+        if name not in EXEMPT_FROM_TEMPLATE
+        for f in dataclasses.fields(declared[name])
+        if not any(f.name in entry for entry in entries)
     )
-    assert unset == []
+    assert unnamed == []
 
 
 def test_unknown_fairness_key_is_refused(tmp_path: Path) -> None:
@@ -234,3 +243,15 @@ def test_a_nested_collection_type_is_refused(tmp_path: Path) -> None:
         load_rai_config(path)
 
     assert "activities[0].collection_types[0]" in str(excinfo.value)
+
+
+def test_the_template_claims_no_model_used_the_dataset() -> None:
+    """A models entry names a third party and asserts it used this dataset.
+
+    Nothing in a template can know that, so the file shows the fields in a
+    comment; a live entry would put a fabricated claim in every bake made
+    from it.
+    """
+    config = load_rai_config(RAI_EXAMPLE)
+
+    assert config.lineage.models == []

--- a/tests/test_rai_loader.py
+++ b/tests/test_rai_loader.py
@@ -1,0 +1,28 @@
+"""Loader tests for the RAI config YAML: the shipped example, and key checking."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+from croissant_baker.rai.loader import load_rai_config
+from croissant_baker.rai.schema import AIFairnessConfig
+
+REPO_ROOT = Path(__file__).parent.parent
+RAI_EXAMPLE = REPO_ROOT / "rai-example.yaml"
+
+
+def test_shipped_example_populates_every_fairness_field() -> None:
+    """Every key in the template must be one the loader actually reads.
+
+    ``--rai-config --help`` points users at ``rai-example.yaml``, so a key the
+    loader does not know is a field silently missing from their output.
+    """
+    config = load_rai_config(RAI_EXAMPLE)
+
+    unset = [
+        f.name
+        for f in dataclasses.fields(AIFairnessConfig)
+        if getattr(config.ai_fairness, f.name) is None
+    ]
+    assert unset == []

--- a/tests/test_rai_loader.py
+++ b/tests/test_rai_loader.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import dataclasses
 from pathlib import Path
 
+import pytest
+
 from croissant_baker.rai.loader import load_rai_config
 from croissant_baker.rai.schema import AIFairnessConfig
 
 REPO_ROOT = Path(__file__).parent.parent
 RAI_EXAMPLE = REPO_ROOT / "rai-example.yaml"
+
+
+def write_config(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "rai.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
 
 
 def test_shipped_example_populates_every_fairness_field() -> None:
@@ -26,3 +34,115 @@ def test_shipped_example_populates_every_fairness_field() -> None:
         if getattr(config.ai_fairness, f.name) is None
     ]
     assert unset == []
+
+
+def test_unknown_fairness_key_is_refused(tmp_path: Path) -> None:
+    """The typo from the template: close enough to look right, silently dropped."""
+    path = write_config(
+        tmp_path,
+        "ai_fairness:\n  social_impact: It enables research.\n",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "ai_fairness.social_impact" in message
+    assert "data_social_impact" in message
+
+
+def test_unknown_top_level_key_is_refused(tmp_path: Path) -> None:
+    path = write_config(tmp_path, "provenance:\n  models: []\n")
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    message = str(excinfo.value)
+    assert "provenance" in message
+    assert "ai_fairness" in message
+    assert "lineage" in message
+    assert "activities" in message
+
+
+def test_unknown_key_inside_an_activity_agent_is_refused(tmp_path: Path) -> None:
+    """The reported path has to say which entry, not just which level."""
+    path = write_config(
+        tmp_path,
+        "activities:\n"
+        "  - id: ACT-001\n"
+        "    type: data_collection\n"
+        "    agents:\n"
+        "      - name: A team\n"
+        "      - nme: A typo\n",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    message = str(excinfo.value)
+    assert "activities[0].agents[1].nme" in message
+    assert "is_synthetic" in message
+
+
+def test_a_config_of_valid_keys_still_loads(tmp_path: Path) -> None:
+    path = write_config(
+        tmp_path,
+        "ai_fairness:\n"
+        "  data_social_impact: It enables research.\n"
+        "  has_synthetic_data: true\n"
+        "lineage:\n"
+        "  source_datasets:\n"
+        "    - url: https://example.org/source\n"
+        "      name: Source\n"
+        "      organisation: Example\n"
+        "      license: CC-BY-4.0\n"
+        "  models:\n"
+        "    - url: https://example.org/model\n"
+        "activities:\n"
+        "  - id: ACT-001\n"
+        "    type: data_collection\n"
+        "    collection_types:\n"
+        "      - observations\n"
+        "    agents:\n"
+        "      - name: A team\n"
+        "        is_synthetic: false\n"
+        "    platforms:\n"
+        "      - name: A tool\n",
+    )
+
+    config = load_rai_config(path)
+
+    assert config.ai_fairness.data_social_impact == "It enables research."
+    assert config.ai_fairness.has_synthetic_data is True
+    assert [s.name for s in config.lineage.source_datasets] == ["Source"]
+    assert [m.url for m in config.lineage.models] == ["https://example.org/model"]
+    assert [a.name for a in config.activities[0].agents] == ["A team"]
+    assert [p.name for p in config.activities[0].platforms] == ["A tool"]
+
+
+def test_an_empty_file_loads_to_an_empty_config(tmp_path: Path) -> None:
+    config = load_rai_config(write_config(tmp_path, ""))
+
+    assert config.ai_fairness == AIFairnessConfig()
+    assert config.lineage.source_datasets == []
+    assert config.lineage.models == []
+    assert config.activities == []
+
+
+def test_a_top_level_list_is_refused(tmp_path: Path) -> None:
+    path = write_config(tmp_path, "- ai_fairness: {}\n")
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    assert str(path) in str(excinfo.value)
+
+
+def test_a_yaml_syntax_error_is_refused(tmp_path: Path) -> None:
+    path = write_config(tmp_path, "ai_fairness:\n  data_biases: [unclosed\n")
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    assert str(path) in str(excinfo.value)

--- a/tests/test_rai_loader.py
+++ b/tests/test_rai_loader.py
@@ -146,3 +146,54 @@ def test_a_yaml_syntax_error_is_refused(tmp_path: Path) -> None:
         load_rai_config(path)
 
     assert str(path) in str(excinfo.value)
+
+
+def test_a_string_of_collection_types_is_refused(tmp_path: Path) -> None:
+    """Iterating a string yields characters, which is never what was meant."""
+    path = write_config(
+        tmp_path,
+        "activities:\n"
+        "  - id: ACT-001\n"
+        "    type: data_collection\n"
+        "    collection_types: observations\n",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "activities[0].collection_types" in message
+
+
+def test_a_mapping_of_collection_types_is_refused(tmp_path: Path) -> None:
+    path = write_config(
+        tmp_path,
+        "activities:\n"
+        "  - id: ACT-001\n"
+        "    type: data_collection\n"
+        "    collection_types:\n"
+        "      observations: true\n",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    assert "activities[0].collection_types" in str(excinfo.value)
+
+
+def test_a_nested_collection_type_is_refused(tmp_path: Path) -> None:
+    """A list entry has to be a value, not another structure."""
+    path = write_config(
+        tmp_path,
+        "activities:\n"
+        "  - id: ACT-001\n"
+        "    type: data_collection\n"
+        "    collection_types:\n"
+        "      - name: observations\n",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_rai_config(path)
+
+    assert "activities[0].collection_types[0]" in str(excinfo.value)

--- a/tests/test_rai_loader.py
+++ b/tests/test_rai_loader.py
@@ -255,3 +255,25 @@ def test_the_template_claims_no_model_used_the_dataset() -> None:
     config = load_rai_config(RAI_EXAMPLE)
 
     assert config.lineage.models == []
+
+
+def test_blank_collection_types_are_dropped(tmp_path: Path) -> None:
+    """Key names are strict; values stay as lenient as they were."""
+    path = write_config(
+        tmp_path,
+        "activities:\n"
+        "  - id: ACT-001\n"
+        "    type: data_collection\n"
+        "    collection_types:\n"
+        "      - observations\n"
+        '      - ""\n'
+        "      - ~\n"
+        "      - existing_datasets\n",
+    )
+
+    config = load_rai_config(path)
+
+    assert config.activities[0].collection_types == [
+        "observations",
+        "existing_datasets",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "croissant-baker"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "h5py" },


### PR DESCRIPTION
Closes #131.

`rai-example.yaml`, which `--rai-config --help` points users at, used `social_impact` where the loader reads `data_social_impact`, so the field was dropped without a word. This fixes the template and makes the loader refuse the class of mistake instead of hiding it.

## Changes

- `rai-example.yaml` uses `data_social_impact`, and the template now shows every field the schema declares (a source dataset `id` and a platform `url` were missing), guarded by a test that walks every dataclass in `rai/schema.py` against the raw YAML of the shipped template. `models` stays `[]` with a commented example, because an entry asserts that a named model used the dataset, so `ModelRef` is the one stated exemption.
- `rai/loader.py` refuses an unknown key at every level (top level, `ai_fairness`, `lineage`, each source dataset and model, each activity, agent and platform) with a `ValueError` naming the file, the key path (for example `activities[0].agents[1].nme`) and the accepted keys, which are derived from the dataclass fields so they cannot drift. A value that is not the mapping or list its level expects, a YAML syntax error, or a non-mapping document are reported the same way. `collection_types` must be a list of scalars; a bare string used to become a list of characters.
- `collection_types` was accepted and then never written: the same failure one level down. It is now emitted as `rai:dataCollectionType` on the dataset node, the deduplicated union across activities in declaration order. Values are written in the wording RAI 1.0 recommends where one exists (`existing_datasets` becomes `Secondary Data analysis`, `observations` becomes `Passive Data Collection`), the three with no RAI term keep their own name in title case, and any other text is written as given because the range is open text. The template and the guide list the pairs. Only there: RAI 1.0 declares the property on the dataset, not on an activity. The RAI reference output gains exactly that key.
- The CLI reads the config before scanning, including under `--dry-run`, so a bad config fails immediately with exit 1 and no traceback. An intended `typer.Exit` raised inside the generate command's `try` was being swallowed by the catch-all and followed by a bare `Unexpected error:` line; it is re-raised now.
- `docs/user-guide/rai.md` says unknown keys are rejected and that `--dry-run` checks the config too.

The message a user now sees for the issue's typo:

```
Error: rai.yaml: unknown key in the RAI config: ai_fairness.social_impact. Accepted keys at ai_fairness: data_biases, data_limitations, data_social_impact, data_use_cases, has_synthetic_data, personal_sensitive_information. Did you mean 'data_social_impact'?
```

## Release note

Two things a config written against an older template will notice:

- The template's old `social_impact` key is now `data_social_impact`. A config still carrying the old key stops the run. The error names the key and suggests the new one.
- A source dataset or model without `url`, or an agent or platform without `name`, stops the run too. Before, those entries were dropped without a word. An activity without `id` or `type` also stops the run. Before, it was written out with an empty `@id` and a blank label.
- A quoted boolean such as `has_synthetic_data: "false"`, and a list or mapping in a text field, are refused. Before, they were written as `true` or as a Python list repr.
- `collection_types` values are translated on the way out (`observations` is written as `Passive Data Collection`), so a document baked from the same config changes those strings.

## Testing

Test-driven: each behaviour has a test that failed before its commit (`tests/test_rai_loader.py`, additions to `tests/test_rai.py`). `uv run pytest -q`: 1013 passed. `uv run pre-commit run --all-files`: all hooks pass. `docs/generate.py`: no diff. `croissant-baker validate` accepts the updated reference output.


